### PR TITLE
add maxcpucount to build options

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -23,9 +23,9 @@ copy build\Release\luvi.exe .
 :publish
 rmdir /s /q build
 cmake -DWithOpenSSL=ON -DWithSharedOpenSSL=OFF -H. -Bbuild
-cmake --build build --config Release
+cmake --build build --config Release -- /maxcpucount
 copy build\Release\luvi.exe luvi-binaries\Windows\luvi.exe
 rmdir /s /q build
 cmake -H. -Bbuild
-cmake --build build --config Release
+cmake --build build --config Release -- /maxcpucount
 copy build\Release\luvi.exe luvi-binaries\Windows\luvi-tiny.exe


### PR DESCRIPTION
This should make the windows builder run in parallel.
