### PR TITLE
Support for Windows Services

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,13 @@ endif (WithZLIB)
 
 add_definitions( -DLUVI_VERSION="${LUVI_VERSION}" )
 
+if(MSVC)
+  set(winsvc src/winsvc.h src/winsvcaux.h src/winsvc.c src/winsvcaux.c)
+  add_definitions(-DWITH_WINSVC)
+endif()
+
 luajit_add_executable(luvi
+  ${winsvc}
   src/main.c
   src/lua/init.lua
 )

--- a/make.bat
+++ b/make.bat
@@ -30,6 +30,25 @@ test.exe
 DEL /Q test.exe
 GOTO :end
 
+:winsvc
+DEL /Q winsvc.exe
+SET LUVI_APP=samples\winsvc.app
+SET LUVI_TARGET=winsvc.exe
+luvi.exe
+SET "LUVI_APP="
+SET "LUVI_TARGET="
+GOTO :end
+
+:repl
+DEL /Q repl.exe
+SET LUVI_APP=samples\repl.app
+SET LUVI_TARGET=repl.exe
+luvi.exe
+SET "LUVI_APP="
+SET "LUVI_TARGET="
+GOTO :end
+
+
 :clean
 IF EXIST build RMDIR /S /Q build
 IF EXIST luvi.exe DEL /F /Q luvi.exe

--- a/samples/winsvc.app/main.lua
+++ b/samples/winsvc.app/main.lua
@@ -199,22 +199,14 @@ end
 local DispatchTable = {}
 DispatchTable[svcname] = SvcHandler;
 
--- Need to roll this into SpawnServiceCtrlDispatch to do it for each svcname
-local svcpipe = uv.new_pipe(false)
-svcpipe:bind(svcname)
-local block
-
-svcpipe:read_start(function(err, chunk)
-  local success, dwControl, dwEventType, lpEventData, lpContext
-  block, success, dwControl, dwEventType, lpEventData, lpContext = winsvc.FormatPipeReadChunk(block, chunk)
+if not winsvc.SpawnServiceCtrlDispatcher(DispatchTable, function(success, err)
   if success then
-    ret = SvcHandler(dwControl, dwEventType, lpEventData, lpContext)
-    svcpipe:write(winsvc.FormatPipeReturn(ret))
+    print('Service ControlDispatcher returned after threads exited ok')
+  else
+    print('Service ControlDispatcher returned eith err', winsvcaux.GetErrorString(err))
   end
-end)
-
-if not winsvc.SpawnServiceCtrlDispatcher(DispatchTable) then
-  SvcReportEvent('ServiceCtrlDispatcher Succeeded')
+end) then
+  SvcReportEvent('SpawnServiceCtrlDispatcher Succeeded')
 end
 
 uv.run('default')

--- a/samples/winsvc.app/main.lua
+++ b/samples/winsvc.app/main.lua
@@ -120,7 +120,7 @@ local function SvcInstall()
   end
 
   -- Create the Service
-  local schService, err = winsvc.CreateService(
+  local schService, tagid, err = winsvc.CreateService(
     schSCManager,
     svcname,
     svcname,
@@ -132,11 +132,10 @@ local function SvcInstall()
     nil,
     nil,
     nil,
-    nil,
     nil)
 
   if schService == nil then
-    print('CreateService failed', err)
+    print('CreateService failed', winsvcaux.GetErrorString(err))
     winsvc.CloseServiceHandle(schSCManager)
     return
   end

--- a/samples/winsvc.app/main.lua
+++ b/samples/winsvc.app/main.lua
@@ -74,9 +74,9 @@ local function SvcInit(args, context)
   -- TO_DO: Setup Serive Work To Be done
   
   local timer = uv.new_timer()
-  uv.timer_start(timer, 1000, 0, function()
+  uv.timer_start(timer, 0, 1000, function()
     if gRunning then
-      uv.timer_set_repeat(timer, 1000)
+      uv.timer_again(timer)
     else
       uv.timer_stop(timer)
       ReportSvcStatus(winsvc.SERVICE_STOPPED, winsvc.NO_ERROR, 0);

--- a/samples/winsvc.app/main.lua
+++ b/samples/winsvc.app/main.lua
@@ -1,0 +1,222 @@
+local winsvc = require('winsvc')
+local winsvcaux = require('winsvcaux')
+local uv = require('uv')
+
+local svcname = 'Test Lua Service'
+local gSvcStatus = {}
+local gServiceStatusHandle
+
+local function ReportSvcStatus(dwCurrentState, dwWin32ExitCode, dwWaitHint)
+  local dwCheckPoint = 1
+
+  -- Fill in the SERVICE_STATUS structure.
+
+  gSvcStatus.dwCurrentState = dwCurrentState
+  gSvcStatus.dwWin32ExitCode = dwWin32ExitCode
+  gSvcStatus.dwWaitHint = dwWaitHint
+
+  if dwCurrentState == winsvc.SERVICE_START_PENDING then
+    gSvcStatus.dwControlsAccepted = 0
+  else
+    gSvcStatus.dwControlsAccepted = winsvc.SERVICE_ACCEPT_STOP
+  end
+
+  if dwCurrentState == winsvc.SERVICE_RUNNING or
+    dwCurrentState == winsvc.SERVICE_STOPPED then
+    gSvcStatus.dwCheckPoint = 0
+  else
+    dwCheckPoint = dwCheckPoint + 1
+    gSvcStatus.dwCheckPoint = dwCheckPoint
+  end
+
+  -- Report the status of the service to the SCM.
+  winsvc.SetServiceStatus(gSvcStatusHandle, gSvcStatus)
+end
+
+
+local function SvcHandler(dwControl, dwEventType, lpEventData, lpContext)
+  -- Handle the requested control code. 
+
+  if dwControl == winsvc.SERVICE_CONTROL_USER_DISPATCHER_RUNNING then
+    gServiceStatusHandle = winsvc.GetStatusHandleFrmContext(lpContext)
+    ServiceMain(winsvc.GetArgsFromContext(lpContext), lpContext)
+    return winsvc.NO_ERROR
+  elseif dwControl == winsvc.SERVICE_CONTROL_STOP then 
+    ReportSvcStatus(winsvc.SERVICE_STOP_PENDING, winsvc.NO_ERROR, 0)
+
+    -- Signal the service to stop.
+
+    gRunning = false
+    ReportSvcStatus(gSvcStatus.dwCurrentState, winsvc.NO_ERROR, 0)
+         
+    return winsvc.NO_ERROR
+  elseif dwControl == winsvc.SERVICE_CONTROL_INTERROGATE then 
+    return winsvc.NO_ERROR
+  else
+    return winsvc.ERROR_CALL_NOT_IMPLEMENTED
+  end
+end
+
+
+local function SvcReportEvent(msg)
+  -- Log that somewhere
+end
+
+
+local function SvcInit(args, context)
+  -- TO_DO: Declare and set any required variables.
+  --   Be sure to periodically call ReportSvcStatus() with 
+  --   SERVICE_START_PENDING. If initialization fails, call
+  --   ReportSvcStatus with SERVICE_STOPPED.
+
+  -- Create an event. The control handler function, SvcCtrlHandler,
+  -- signals this event when it receives the stop control code.
+
+  ReportSvcStatus(winsvc.SERVICE_RUNNING, winsvc.NO_ERROR, 0)
+
+  -- TO_DO: Setup Serive Work To Be done
+  
+  local timer = uv.new_timer()
+  uv.timer_start(timer, 1000, 0, function()
+    if gRunning then
+      uv.time_set_repeat(timer, 1000)
+    else
+      uv.timer_stop(timer)
+      ReportSvcStatus(winsvc.SERVICE_STOPPED, winsvc.NO_ERROR, 0);
+      winsvc.EndService(context)
+    end
+  end)
+end
+
+
+local function SvcMain(args, context)
+  -- These SERVICE_STATUS members remain as set here
+
+  gSvcStatus.dwServiceType = winsvc.SERVICE_WIN32_OWN_PROCESS
+  gSvcStatus.dwServiceSpecificExitCode = 0
+
+  -- Report initial status to the SCM
+
+  ReportSvcStatus(winsvc.SERVICE_START_PENDING, winsvc.NO_ERROR, 3000)
+
+  -- Perform service-specific initialization and work.
+
+  SvcInit(args, context)
+end
+
+
+local function SvcInstall()
+  local svcPath, err = winsvcaux.GetModuleFileName('')
+  if svcPath == nil then
+    print('Cannot install service, service path unobtainable', winsvcaux.GetErrorString(err))
+    return
+  end
+
+  -- Get a handle to the SCM database
+  local schSCManager, err = winsvc.OpenSCManager(nil, nil, winsvc.SC_MANAGER_ALL_ACCESS)
+  if schSCManager == nil then
+    print('OpenSCManager failed', winsvcaux.GetErrorString(err))
+    return
+  end
+
+  -- Create the Service
+  local schService, err = winsvc.CreateService(
+    schSCManager,
+    svcname,
+    svcname,
+    winsvc.SERVICE_ALL_ACCESS,
+    winsvc.SERVICE_WIN32_OWN_PROCESS,
+    winsvc.SERVICE_DEMAND_START,
+    winsvc.SERVICE_ERROR_NORMAL,
+    svcPath,
+    nil,
+    nil,
+    nil,
+    nil,
+    nil)
+
+  if schService == nil then
+    print('CreateService failed', err)
+    winsvc.CloseServiceHandle(schSCManager)
+    return
+  end
+
+  print('Service installed successfully')
+
+  winsvc.CloseServiceHandle(schService)
+  winsvc.CloseServiceHandle(schSCManager)
+
+end
+
+
+local function SvcDelete()
+  -- Get a handle to the SCM database
+  local schSCManager, err = winsvc.OpenSCManager(nil, nil, winsvc.SC_MANAGER_ALL_ACCESS)
+  if schSCManager == nil then
+    print('OpenSCManager failed', winsvcaux.GetErrorString(err))
+    return
+  end
+
+  -- Open the Service
+  local schService, err = winsvc.OpenService(
+    schSCManager,
+    svcname,
+    winsvc.DELETE)
+
+  if schService == nil then
+    print('OpenService failed', winsvcaux.GetErrorString(err))
+    winsvc.CloseServiceHandle(schSCManager)
+    return
+  end
+
+  -- Delete the Service
+  local schService = winsvc.OpenService(
+    schSCManager,
+    svcname,
+    winsvc.DELETE)
+
+  local delsuccess, err = winsvc.DeleteService(schService)
+  if not delsuccess then
+    print('DeleteService failed', winsvcaux.GetErrorString(err))
+  else
+    print('DeleteService succeeded')
+  end
+
+  winsvc.CloseServiceHandle(schService)
+  winsvc.CloseServiceHandle(schSCManager)
+
+end
+
+
+-- Main Code
+
+if args[2] == 'install' then
+  SvcInstall()
+  return
+elseif args[2] == 'delete' then
+  SvcDelete()
+  return
+end
+
+local DispatchTable = {}
+DispatchTable[svcname] = SvcHandler;
+
+-- Need to roll this into SpawnServiceCtrlDispatch to do it for each svcname
+local svcpipe = uv.new_pipe(false)
+svcpipe:bind(svcname)
+local block
+
+svcpipe:read_start(function(err, chunk)
+  local success, dwControl, dwEventType, lpEventData, lpContext
+  block, success, dwControl, dwEventType, lpEventData, lpContext = winsvc.FormatPipeReadChunk(block, chunk)
+  if success then
+    ret = SvcHandler(dwControl, dwEventType, lpEventData, lpContext)
+    svcpipe:write(winsvc.FormatPipeReturn(ret))
+  end
+end)
+
+if not winsvc.SpawnServiceCtrlDispatcher(DispatchTable) then
+  SvcReportEvent('ServiceCtrlDispatcher Succeeded')
+end
+
+uv.run('default')

--- a/samples/winsvc.app/main.lua
+++ b/samples/winsvc.app/main.lua
@@ -106,7 +106,7 @@ end
 
 
 local function SvcInstall()
-  local svcPath, err = winsvcaux.GetModuleFileName('')
+  local svcPath, err = winsvcaux.GetModuleFileName()
   if svcPath == nil then
     print('Cannot install service, service path unobtainable', winsvcaux.GetErrorString(err))
     return
@@ -189,11 +189,10 @@ end
 
 
 -- Main Code
-
-if args[2] == 'install' then
+if args[1] == 'install' then
   SvcInstall()
   return
-elseif args[2] == 'delete' then
+elseif args[1] == 'delete' then
   SvcDelete()
   return
 end

--- a/samples/winsvc.app/main.lua
+++ b/samples/winsvc.app/main.lua
@@ -1,3 +1,21 @@
+--[[
+
+Copyright 2015 The Luvit Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+--]]
+
 local winsvc = require('winsvc')
 local winsvcaux = require('winsvcaux')
 local uv = require('uv')
@@ -79,6 +97,7 @@ local function SvcInit(args, context)
       uv.timer_again(timer)
     else
       uv.timer_stop(timer)
+      uv.close(timer)
       ReportSvcStatus(winsvc.SERVICE_STOPPED, winsvc.NO_ERROR, 0);
       winsvc.EndService(context)
     end

--- a/src/main.c
+++ b/src/main.c
@@ -26,6 +26,10 @@
 #ifdef WITH_ZLIB
 LUALIB_API int luaopen_zlib(lua_State * const L);
 #endif
+#ifdef WITH_WINSVC
+#include "winsvc.h"
+#include "winsvcaux.h"
+#endif
 
 int main(int argc, char* argv[] ) {
 
@@ -75,6 +79,14 @@ int main(int argc, char* argv[] ) {
   // Store luvi module definition at preload.openssl
   lua_pushcfunction(L, luaopen_zlib);
   lua_setfield(L, -2, "zlib");
+#endif
+
+#ifdef WITH_WINSVC
+  // Store luvi module definition at preload.openssl
+  lua_pushcfunction(L, luaopen_winsvc);
+  lua_setfield(L, -2, "winsvc");
+  lua_pushcfunction(L, luaopen_winsvcaux);
+  lua_setfield(L, -2, "winsvcaux");
 #endif
 
   // Load the init.lua script

--- a/src/winsvc.c
+++ b/src/winsvc.c
@@ -54,19 +54,6 @@ typedef struct _svc_baton {
 /* linked list of batons */
 svc_baton* gBatons = NULL;
 
-static lua_State* luv_state(uv_loop_t* loop) {
-  return loop->data;
-}
-
-static uv_loop_t* luv_loop(lua_State* L) {
-  uv_loop_t* loop;
-  lua_pushstring(L, "uv_loop");
-  lua_rawget(L, LUA_REGISTRYINDEX);
-  loop = lua_touserdata(L, -1);
-  lua_pop(L, 1);
-  return loop;
-}
-
 static DWORD GetDWFromTable(lua_State *L, const char* name) {
   DWORD result;
   lua_pushstring(L, name);

--- a/src/winsvc.c
+++ b/src/winsvc.c
@@ -1,3 +1,19 @@
+/*
+*  Copyright 2014 The Luvit Authors. All Rights Reserved.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*/
 #include "luvi.h"
 
 #include <windows.h>

--- a/src/winsvc.c
+++ b/src/winsvc.c
@@ -1,6 +1,7 @@
 #include "luvi.h"
 
 #include <windows.h>
+#include <winsvc.h>
 #include <strsafe.h>
 
 #define SERVICE_CONTROL_USER_REGISTER_HANDLER_FAIL		0x00000080
@@ -252,8 +253,8 @@ static int lua_SpawnServiceCtrlDispatcher(lua_State *L)
 
 static int lua_OpenSCManager(lua_State *L)
 {
-  const char* machinename = luaL_checkstring(L, 1);
-  const char* databasename = luaL_checkstring(L, 2);
+  const char* machinename = lua_tostring(L, 1);
+  const char* databasename = lua_tostring(L, 2);
   DWORD access = luaL_checkint(L, 3);
   SC_HANDLE h = OpenSCManager(machinename, databasename, access);
   if (h != NULL)
@@ -298,14 +299,15 @@ static int lua_CreateService(lua_State *L)
   DWORD starttype = luaL_checkint(L, 6);
   DWORD errorcontrol = luaL_checkint(L, 7);
   const char* pathname = luaL_checkstring(L, 8);
-  const char* loadordergroup = luaL_checkstring(L, 9);
+  const char* loadordergroup = lua_tostring(L, 9);
   DWORD tagid = 0;
-  const char* deps = luaL_checkstring(L, 10);
-  const char* username = luaL_checkstring(L, 11);
-  const char* password = luaL_checkstring(L, 12);
+  DWORD *tagidp = loadordergroup?&tagid:NULL;
+  const char* deps = lua_tostring(L, 10);
+  const char* username = lua_tostring(L, 11);
+  const char* password = lua_tostring(L, 12);
 
 
-  SC_HANDLE h = CreateService(hSCManager, servicename, displayname, access, servicetype, starttype, errorcontrol, pathname, loadordergroup, &tagid, deps, username, password);
+  SC_HANDLE h = CreateService(hSCManager, servicename, displayname, access, servicetype, starttype, errorcontrol, pathname, loadordergroup, tagidp, deps, username, password);
   if (h != NULL)
   {
     lua_pushlightuserdata(L, h);
@@ -382,6 +384,35 @@ LUALIB_API int luaopen_winsvc(lua_State *L) {
   SETINT(ERROR);
   SETINT(ERROR_CALL_NOT_IMPLEMENTED);
   SETINT(NO_ERROR);
+
+  // Service defines from winnt.h
+  SETINT(SERVICE_KERNEL_DRIVER);
+  SETINT(SERVICE_FILE_SYSTEM_DRIVER);
+  SETINT(SERVICE_ADAPTER);
+  SETINT(SERVICE_RECOGNIZER_DRIVER);
+  SETINT(SERVICE_DRIVER);
+  SETINT(SERVICE_WIN32_OWN_PROCESS);
+  SETINT(SERVICE_WIN32_SHARE_PROCESS);
+  SETINT(SERVICE_WIN32);
+  SETINT(SERVICE_INTERACTIVE_PROCESS);
+  SETINT(SERVICE_TYPE_ALL);
+
+  SETINT(SERVICE_BOOT_START);
+  SETINT(SERVICE_SYSTEM_START);
+  SETINT(SERVICE_AUTO_START);
+  SETINT(SERVICE_DEMAND_START);
+  SETINT(SERVICE_DISABLED);
+
+  SETINT(SERVICE_ERROR_IGNORE);
+  SETINT(SERVICE_ERROR_NORMAL);
+  SETINT(SERVICE_ERROR_SEVERE);
+  SETINT(SERVICE_ERROR_CRITICAL);
+
+  SETINT(DELETE);
+  SETINT(READ_CONTROL);
+  SETINT(WRITE_DAC);
+  SETINT(WRITE_OWNER);
+  SETINT(SYNCHRONIZE);
 
   // Service Defines
   SETLITERAL(SERVICES_ACTIVE_DATABASE);

--- a/src/winsvc.c
+++ b/src/winsvc.c
@@ -1,0 +1,565 @@
+#include "luvi.h"
+
+#include <windows.h>
+#include <strsafe.h>
+
+#define SERVICE_CONTROL_USER_REGISTER_HANDLER_FAIL		0x00000080
+#define SERVICE_CONTROL_USER_DISPATCHER_RUNNING			0x00000081
+
+struct svc_baton {
+  const char* name;
+  HANDLE end_event;
+  SERVICE_STATUS_HANDLE status_handle;
+  HANDLE* pipe;
+  DWORD dwArgc;
+  LPTSTR *lpszArgv;
+};
+
+struct svc_handler_block {
+  DWORD dwControl;
+  DWORD dwEventType;
+  LPVOID lpEventData;
+  LPVOID lpContext;
+};
+
+DWORD GetDWFromTable(lua_State *L, const char* name)
+{
+  DWORD result;
+  lua_pushstring(L, name);
+  lua_gettable(L, -2);  /* get table[key] */
+  result = (int)lua_tonumber(L, -1);
+  lua_pop(L, 1);  /* remove number */
+  return result;
+}
+
+HANDLE* GetPipeHandle(const char* name)
+{
+  char pipename[MAX_PATH] = { '\0' };
+  StringCchCat(pipename, MAX_PATH, TEXT("\\\\.\\pipe\\"));
+  StringCchCat(pipename, MAX_PATH, name);
+  HANDLE pipe = CreateFile(
+    pipename,
+    GENERIC_READ |  // read and write access 
+    GENERIC_WRITE,
+    0,              // no sharing 
+    NULL,           // default security attributes
+    OPEN_EXISTING,  // opens existing pipe 
+    0,              // default attributes 
+    NULL);          // no template file
+
+  return pipe;
+}
+
+DWORD WINAPI HandlerEx(
+  _In_  DWORD dwControl,
+  _In_  DWORD dwEventType,
+  _In_  LPVOID lpEventData,
+  _In_  LPVOID lpContext)
+{
+  struct svc_baton *baton = lpContext;
+  struct svc_handler_block block = { dwControl, dwEventType, lpEventData, lpContext };
+  DWORD byteswritten, bytesread;
+  DWORD returncode = ERROR;
+
+  BOOL ret = WriteFile(baton->pipe, &block, sizeof(block), &byteswritten, NULL);
+  if (ret) {
+    BOOL ret = ReadFile(baton->pipe, &returncode, sizeof(returncode), &bytesread, NULL);
+  }
+
+  return returncode;
+}
+
+VOID WINAPI ServiceMain(_In_  DWORD dwArgc, _In_  LPTSTR *lpszArgv)
+{
+  struct svc_baton baton;
+  baton.name = lpszArgv[0];
+  baton.end_event = CreateEvent(NULL, FALSE, FALSE, baton.name);
+  baton.pipe = GetPipeHandle(baton.name);
+  baton.status_handle = RegisterServiceCtrlHandlerEx(baton.name, HandlerEx, &baton);
+  baton.dwArgc = dwArgc;
+  baton.lpszArgv = lpszArgv;
+
+  if (baton.status_handle == 0)
+  {
+    HandlerEx(SERVICE_CONTROL_USER_REGISTER_HANDLER_FAIL, 0, 0, &baton);
+  }
+  else
+  {
+    HandlerEx(SERVICE_CONTROL_USER_DISPATCHER_RUNNING, 0, 0, &baton);
+    WaitForSingleObject(baton.end_event, INFINITE);
+  }
+  CloseHandle(baton.pipe);
+  CloseHandle(baton.end_event);
+}
+
+static int lua_GetStatusHandleFromContext(lua_State *L)
+{
+  struct svc_baton* baton = lua_touserdata(L, 1);
+  lua_pushlightuserdata(L, baton->status_handle);
+  return 1;
+}
+
+static int lua_EndService(lua_State *L)
+{
+  struct svc_baton* baton = lua_touserdata(L, 1);
+  SetEvent(baton->end_event);
+  return 0;
+}
+
+static int lua_FormatPipeReturn(lua_State *L)
+{
+  DWORD ret = luaL_checkint(L, 1);
+  lua_pushlstring(L, (char*)&ret, sizeof(ret));
+  return 1;
+}
+
+static int lua_FormatPipeReadChunk(lua_State *L)
+{
+  size_t chunklen, blocklen;
+  const char* block = luaL_checklstring(L, 1, &blocklen);
+  const char* chunk = luaL_checklstring(L, 2, &chunklen);
+  size_t combinedlen = blocklen + chunklen;
+  char* combined = (char*)malloc(combinedlen);
+
+  memcpy(combined, block, blocklen);
+  memcpy(combined + blocklen, chunk, chunklen);
+
+  if (blocklen + chunklen >= sizeof(struct svc_handler_block))
+  {
+    struct svc_handler_block svcblock;
+    char * blockreturned;
+    size_t blockreturnedsz;
+
+    memcpy(&svcblock, combined, sizeof(svcblock));
+    blockreturned = combined + sizeof(svcblock);
+    blockreturnedsz = combinedlen - sizeof(svcblock);
+
+    // block, success, dwControl, dwEventType, lpEventData, lpContext
+    lua_pushlstring(L, blockreturned, blockreturnedsz);
+    lua_pushboolean(L, TRUE);
+    lua_pushinteger(L, svcblock.dwControl);
+    lua_pushinteger(L, svcblock.dwEventType);
+    lua_pushlightuserdata(L, svcblock.lpEventData);
+    lua_pushlightuserdata(L, svcblock.lpContext);
+    free(combined);
+    return 6;
+  }
+  else
+  {
+    lua_pushlstring(L, combined, combinedlen);
+    lua_pushboolean(L, FALSE);
+    free(combined);
+    return 2;
+  }
+}
+
+static int lua_GetServiceArgsFromContext(lua_State *L)
+{
+  struct svc_baton* baton = lua_touserdata(L, 1);
+  lua_newtable(L);
+  for (unsigned int i = 0; i <= baton->dwArgc; i++) {
+    lua_pushnumber(L, i + 1);   /* Push the table index */
+    lua_pushstring(L, baton->lpszArgv[i]); /* Push the cell value */
+    lua_rawset(L, -3);      /* Stores the pair in the table */
+  }
+  return 1;
+}
+
+static int lua_SetServiceStatus(lua_State *L)
+{
+  SERVICE_STATUS status;
+  SERVICE_STATUS_HANDLE SvcCtrlHandler = lua_touserdata(L, 1);
+  if (!lua_istable(L, 2))
+  {
+    return luaL_error(L, "table expected");
+  }
+
+  status.dwCheckPoint = GetDWFromTable(L, "dwCheckPoint");
+  status.dwControlsAccepted = GetDWFromTable(L, "dwControlsAccepted");
+  status.dwCurrentState = GetDWFromTable(L, "dwCurrentState");
+  status.dwServiceSpecificExitCode = GetDWFromTable(L, "dwServiceSpecificExitCode");
+  status.dwServiceType = GetDWFromTable(L, "dwServiceType");
+  status.dwWaitHint = GetDWFromTable(L, "dwWaitHint");
+  status.dwWin32ExitCode = GetDWFromTable(L, "dwWin32ExitCode");
+
+  BOOL ret = SetServiceStatus(SvcCtrlHandler, (LPSERVICE_STATUS)&status);
+  if (ret)
+  {
+    lua_pushboolean(L, ret);
+    lua_pushnil(L);
+  }
+  else
+  {
+    lua_pushnil(L);
+    lua_pushinteger(L, GetLastError());
+  }
+  return 2;
+}
+
+DWORD StartServiceCtrlDispatcherThread(LPVOID lpdwThreadParam)
+{
+  SERVICE_TABLE_ENTRY *svc_table = (SERVICE_TABLE_ENTRY*)lpdwThreadParam;
+  return StartServiceCtrlDispatcher(svc_table);
+}
+
+static int lua_SpawnServiceCtrlDispatcher(lua_State *L)
+{
+  /* Get a table */
+  BOOL ret = FALSE;
+  if (!lua_istable(L, 1))
+  {
+    return luaL_error(L, "table expected");
+  }
+
+  size_t len = lua_objlen(L, 1);
+  unsigned int i = 0;
+  SERVICE_TABLE_ENTRY *svc_table = malloc(sizeof(SERVICE_TABLE_ENTRY) * (len + 1));
+  /* Convert the table to a service table */
+  lua_pushnil(L);  /* first key */
+  while (lua_next(L, 1) != 0) {
+    /* uses 'key' (at index -2) and 'value' (at index -1) */
+    const char* name = luaL_checkstring(L, -2);
+    int svchandler = luaL_ref(L, -1);
+
+    svc_table[i].lpServiceName = (LPSTR)name;
+    svc_table[i].lpServiceProc = ServiceMain;
+
+    ++i;
+
+    /* removes 'value'; keeps 'key' for next iteration */
+    lua_pop(L, 1);
+  }
+
+  svc_table[i].lpServiceName = NULL;
+  svc_table[i].lpServiceProc = NULL;
+
+
+  /* Start */
+  HANDLE thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)&StartServiceCtrlDispatcherThread, svc_table, 0, NULL);
+  ret = thread != NULL;
+
+  lua_pushboolean(L, ret);
+  if (ret)
+  {
+    lua_pushnil(L);
+  }
+  else
+  {
+    lua_pushinteger(L, GetLastError());
+  }
+  return 2;
+}
+
+static int lua_OpenSCManager(lua_State *L)
+{
+  const char* machinename = luaL_checkstring(L, 1);
+  const char* databasename = luaL_checkstring(L, 2);
+  DWORD access = luaL_checkint(L, 3);
+  SC_HANDLE h = OpenSCManager(machinename, databasename, access);
+  if (h != NULL)
+  {
+    lua_pushlightuserdata(L, h);
+    lua_pushnil(L);
+  }
+  else
+  {
+    lua_pushnil(L);
+    lua_pushinteger(L, GetLastError());
+  }
+  return 2;
+}
+
+static int lua_OpenService(lua_State *L)
+{
+  SC_HANDLE hSCManager = lua_touserdata(L, 1);
+  const char* servicename = luaL_checkstring(L, 2);
+  DWORD access = luaL_checkint(L, 3);
+  SC_HANDLE h = OpenService(hSCManager, servicename, access);
+  if (h != NULL)
+  {
+    lua_pushlightuserdata(L, h);
+    lua_pushnil(L);
+  }
+  else
+  {
+    lua_pushnil(L);
+    lua_pushinteger(L, GetLastError());
+  }
+  return 2;
+}
+
+static int lua_CreateService(lua_State *L)
+{
+  SC_HANDLE hSCManager = lua_touserdata(L, 1);
+  const char* servicename = luaL_checkstring(L, 2);
+  const char* displayname = luaL_checkstring(L, 3);
+  DWORD access = luaL_checkint(L, 4);
+  DWORD servicetype = luaL_checkint(L, 5);
+  DWORD starttype = luaL_checkint(L, 6);
+  DWORD errorcontrol = luaL_checkint(L, 7);
+  const char* pathname = luaL_checkstring(L, 8);
+  const char* loadordergroup = luaL_checkstring(L, 9);
+  DWORD tagid = 0;
+  const char* deps = luaL_checkstring(L, 10);
+  const char* username = luaL_checkstring(L, 11);
+  const char* password = luaL_checkstring(L, 12);
+
+
+  SC_HANDLE h = CreateService(hSCManager, servicename, displayname, access, servicetype, starttype, errorcontrol, pathname, loadordergroup, &tagid, deps, username, password);
+  if (h != NULL)
+  {
+    lua_pushlightuserdata(L, h);
+    lua_pushinteger(L, tagid);
+    lua_pushnil(L);
+  }
+  else
+  {
+    lua_pushnil(L);
+    lua_pushnil(L);
+    lua_pushinteger(L, GetLastError());
+  }
+  return 3;
+}
+
+static int lua_CloseServiceHandle(lua_State *L)
+{
+  SC_HANDLE h = lua_touserdata(L, 1);
+  BOOL ret = CloseServiceHandle(h);
+  lua_pushboolean(L, ret);
+  if (ret)
+  {
+    lua_pushnil(L);
+  }
+  else
+  {
+    lua_pushinteger(L, GetLastError());
+  }
+  return 2;
+}
+
+static int lua_DeleteService(lua_State *L)
+{
+  SC_HANDLE h = lua_touserdata(L, 1);
+  BOOL ret = DeleteService(h);
+  lua_pushboolean(L, ret);
+  if (ret)
+  {
+    lua_pushnil(L);
+  }
+  else
+  {
+    lua_pushinteger(L, GetLastError());
+  }
+  return 2;
+}
+
+static const luaL_Reg winsvclib[] = {
+    { "GetStatusHandleFromContext", lua_GetStatusHandleFromContext },
+    { "GetServiceArgsFromContext", lua_GetServiceArgsFromContext },
+    { "FormatPipeReadChunk", lua_FormatPipeReadChunk },
+    { "FormatPipeReturn", lua_FormatPipeReturn },
+    { "EndService", lua_EndService },
+    { "SetServiceStatus", lua_SetServiceStatus },
+    { "SpawnServiceCtrlDispatcher", lua_SpawnServiceCtrlDispatcher },
+    { "OpenSCManager", lua_OpenSCManager },
+    { "CloseServiceHandle", lua_CloseServiceHandle },
+    { "CreateService", lua_CreateService },
+    { "OpenService", lua_OpenService },
+    { "DeleteService", lua_DeleteService },
+    { NULL, NULL }
+};
+
+#define SETLITERAL(v) (lua_pushliteral(L, #v), lua_pushliteral(L, v), lua_settable(L, -3))
+#define SETINT(v) (lua_pushliteral(L, #v), lua_pushinteger(L, v), lua_settable(L, -3))
+
+/*
+** Open Windows service library
+*/
+LUALIB_API int luaopen_winsvc(lua_State *L) {
+  luaL_register(L, "winsvc", winsvclib);
+
+  // Some Windows Defines
+  SETINT(ERROR);
+  SETINT(ERROR_CALL_NOT_IMPLEMENTED);
+  SETINT(NO_ERROR);
+
+  // Service Defines
+  SETLITERAL(SERVICES_ACTIVE_DATABASE);
+  SETLITERAL(SERVICES_FAILED_DATABASE);
+  SETINT(SC_GROUP_IDENTIFIER);
+
+  SETINT(SERVICE_NO_CHANGE);
+
+  SETINT(SERVICE_ACTIVE);
+  SETINT(SERVICE_INACTIVE);
+  SETINT(SERVICE_STATE_ALL);
+
+  SETINT(SERVICE_CONTROL_STOP);
+  SETINT(SERVICE_CONTROL_PAUSE);
+  SETINT(SERVICE_CONTROL_CONTINUE);
+  SETINT(SERVICE_CONTROL_INTERROGATE);
+  SETINT(SERVICE_CONTROL_SHUTDOWN);
+  SETINT(SERVICE_CONTROL_PARAMCHANGE);
+  SETINT(SERVICE_CONTROL_NETBINDADD);
+  SETINT(SERVICE_CONTROL_NETBINDREMOVE);
+  SETINT(SERVICE_CONTROL_NETBINDENABLE);
+  SETINT(SERVICE_CONTROL_NETBINDDISABLE);
+  SETINT(SERVICE_CONTROL_DEVICEEVENT);
+  SETINT(SERVICE_CONTROL_HARDWAREPROFILECHANGE);
+  SETINT(SERVICE_CONTROL_POWEREVENT);
+  SETINT(SERVICE_CONTROL_SESSIONCHANGE);
+  SETINT(SERVICE_CONTROL_PRESHUTDOWN);
+  SETINT(SERVICE_CONTROL_TIMECHANGE);
+  SETINT(SERVICE_CONTROL_TRIGGEREVENT);
+  SETINT(SERVICE_CONTROL_USER_REGISTER_HANDLER_FAIL);
+
+  SETINT(SERVICE_STOPPED);
+  SETINT(SERVICE_START_PENDING);
+  SETINT(SERVICE_STOP_PENDING);
+  SETINT(SERVICE_RUNNING);
+  SETINT(SERVICE_CONTINUE_PENDING);
+  SETINT(SERVICE_PAUSE_PENDING);
+  SETINT(SERVICE_PAUSED);
+
+  SETINT(SERVICE_ACCEPT_STOP);
+  SETINT(SERVICE_ACCEPT_PAUSE_CONTINUE);
+  SETINT(SERVICE_ACCEPT_SHUTDOWN);
+  SETINT(SERVICE_ACCEPT_PARAMCHANGE);
+  SETINT(SERVICE_ACCEPT_NETBINDCHANGE);
+  SETINT(SERVICE_ACCEPT_HARDWAREPROFILECHANGE);
+  SETINT(SERVICE_ACCEPT_POWEREVENT);
+  SETINT(SERVICE_ACCEPT_SESSIONCHANGE);
+  SETINT(SERVICE_ACCEPT_PRESHUTDOWN);
+  SETINT(SERVICE_ACCEPT_TIMECHANGE);
+  SETINT(SERVICE_ACCEPT_TRIGGEREVENT);
+
+  SETINT(SC_MANAGER_CONNECT);
+  SETINT(SC_MANAGER_CREATE_SERVICE);
+  SETINT(SC_MANAGER_ENUMERATE_SERVICE);
+  SETINT(SC_MANAGER_LOCK);
+  SETINT(SC_MANAGER_QUERY_LOCK_STATUS);
+  SETINT(SC_MANAGER_MODIFY_BOOT_CONFIG);
+  SETINT(SC_MANAGER_ALL_ACCESS);
+
+  SETINT(SERVICE_QUERY_CONFIG);
+  SETINT(SERVICE_CHANGE_CONFIG);
+  SETINT(SERVICE_QUERY_STATUS);
+  SETINT(SERVICE_ENUMERATE_DEPENDENTS);
+  SETINT(SERVICE_START);
+  SETINT(SERVICE_STOP);
+  SETINT(SERVICE_PAUSE_CONTINUE);
+  SETINT(SERVICE_INTERROGATE);
+  SETINT(SERVICE_USER_DEFINED_CONTROL);
+  SETINT(SERVICE_ALL_ACCESS);
+
+  SETINT(SERVICE_RUNS_IN_SYSTEM_PROCESS);
+
+  SETINT(SERVICE_CONFIG_DESCRIPTION);
+  SETINT(SERVICE_CONFIG_FAILURE_ACTIONS);
+  SETINT(SERVICE_CONFIG_DELAYED_AUTO_START_INFO);
+  SETINT(SERVICE_CONFIG_FAILURE_ACTIONS_FLAG);
+  SETINT(SERVICE_CONFIG_SERVICE_SID_INFO);
+  SETINT(SERVICE_CONFIG_REQUIRED_PRIVILEGES_INFO);
+  SETINT(SERVICE_CONFIG_PRESHUTDOWN_INFO);
+  SETINT(SERVICE_CONFIG_TRIGGER_INFO);
+  SETINT(SERVICE_CONFIG_PREFERRED_NODE);
+  // reserved                                     10
+  // reserved                                     11
+  SETINT(SERVICE_CONFIG_LAUNCH_PROTECTED);
+
+  SETINT(SERVICE_NOTIFY_STATUS_CHANGE_1);
+  SETINT(SERVICE_NOTIFY_STATUS_CHANGE_2);
+  SETINT(SERVICE_NOTIFY_STATUS_CHANGE);
+
+  SETINT(SERVICE_NOTIFY_STOPPED);
+  SETINT(SERVICE_NOTIFY_START_PENDING);
+  SETINT(SERVICE_NOTIFY_STOP_PENDING);
+  SETINT(SERVICE_NOTIFY_RUNNING);
+  SETINT(SERVICE_NOTIFY_CONTINUE_PENDING);
+  SETINT(SERVICE_NOTIFY_PAUSE_PENDING);
+  SETINT(SERVICE_NOTIFY_PAUSED);
+  SETINT(SERVICE_NOTIFY_CREATED);
+  SETINT(SERVICE_NOTIFY_DELETED);
+  SETINT(SERVICE_NOTIFY_DELETE_PENDING);
+
+  SETINT(SERVICE_STOP_REASON_FLAG_MIN);
+  SETINT(SERVICE_STOP_REASON_FLAG_UNPLANNED);
+  SETINT(SERVICE_STOP_REASON_FLAG_CUSTOM);
+  SETINT(SERVICE_STOP_REASON_FLAG_PLANNED);
+  SETINT(SERVICE_STOP_REASON_FLAG_MAX);
+
+  SETINT(SERVICE_STOP_REASON_MAJOR_MIN);
+  SETINT(SERVICE_STOP_REASON_MAJOR_OTHER);
+  SETINT(SERVICE_STOP_REASON_MAJOR_HARDWARE);
+  SETINT(SERVICE_STOP_REASON_MAJOR_OPERATINGSYSTEM);
+  SETINT(SERVICE_STOP_REASON_MAJOR_SOFTWARE);
+  SETINT(SERVICE_STOP_REASON_MAJOR_APPLICATION);
+  SETINT(SERVICE_STOP_REASON_MAJOR_NONE);
+  SETINT(SERVICE_STOP_REASON_MAJOR_MAX);
+  SETINT(SERVICE_STOP_REASON_MAJOR_MIN_CUSTOM);
+  SETINT(SERVICE_STOP_REASON_MAJOR_MAX_CUSTOM);
+
+  SETINT(SERVICE_STOP_REASON_MINOR_MIN);
+  SETINT(SERVICE_STOP_REASON_MINOR_OTHER);
+  SETINT(SERVICE_STOP_REASON_MINOR_MAINTENANCE);
+  SETINT(SERVICE_STOP_REASON_MINOR_INSTALLATION);
+  SETINT(SERVICE_STOP_REASON_MINOR_UPGRADE);
+  SETINT(SERVICE_STOP_REASON_MINOR_RECONFIG);
+  SETINT(SERVICE_STOP_REASON_MINOR_HUNG);
+  SETINT(SERVICE_STOP_REASON_MINOR_UNSTABLE);
+  SETINT(SERVICE_STOP_REASON_MINOR_DISK);
+  SETINT(SERVICE_STOP_REASON_MINOR_NETWORKCARD);
+  SETINT(SERVICE_STOP_REASON_MINOR_ENVIRONMENT);
+  SETINT(SERVICE_STOP_REASON_MINOR_HARDWARE_DRIVER);
+  SETINT(SERVICE_STOP_REASON_MINOR_OTHERDRIVER);
+  SETINT(SERVICE_STOP_REASON_MINOR_SERVICEPACK);
+  SETINT(SERVICE_STOP_REASON_MINOR_SOFTWARE_UPDATE);
+  SETINT(SERVICE_STOP_REASON_MINOR_SECURITYFIX);
+  SETINT(SERVICE_STOP_REASON_MINOR_SECURITY);
+  SETINT(SERVICE_STOP_REASON_MINOR_NETWORK_CONNECTIVITY);
+  SETINT(SERVICE_STOP_REASON_MINOR_WMI);
+  SETINT(SERVICE_STOP_REASON_MINOR_SERVICEPACK_UNINSTALL);
+  SETINT(SERVICE_STOP_REASON_MINOR_SOFTWARE_UPDATE_UNINSTALL);
+  SETINT(SERVICE_STOP_REASON_MINOR_SECURITYFIX_UNINSTALL);
+  SETINT(SERVICE_STOP_REASON_MINOR_MMC);
+  SETINT(SERVICE_STOP_REASON_MINOR_NONE);
+  SETINT(SERVICE_STOP_REASON_MINOR_MAX);
+  SETINT(SERVICE_STOP_REASON_MINOR_MIN_CUSTOM);
+  SETINT(SERVICE_STOP_REASON_MINOR_MAX_CUSTOM);
+
+  SETINT(SERVICE_CONTROL_STATUS_REASON_INFO);
+
+  SETINT(SERVICE_SID_TYPE_NONE);
+  SETINT(SERVICE_SID_TYPE_UNRESTRICTED);
+  SETINT(SERVICE_SID_TYPE_RESTRICTED);
+
+  SETINT(SERVICE_TRIGGER_TYPE_DEVICE_INTERFACE_ARRIVAL);
+  SETINT(SERVICE_TRIGGER_TYPE_IP_ADDRESS_AVAILABILITY);
+  SETINT(SERVICE_TRIGGER_TYPE_DOMAIN_JOIN);
+  SETINT(SERVICE_TRIGGER_TYPE_FIREWALL_PORT_EVENT);
+  SETINT(SERVICE_TRIGGER_TYPE_GROUP_POLICY);
+  SETINT(SERVICE_TRIGGER_TYPE_NETWORK_ENDPOINT);
+  SETINT(SERVICE_TRIGGER_TYPE_CUSTOM_SYSTEM_STATE_CHANGE);
+  SETINT(SERVICE_TRIGGER_TYPE_CUSTOM);
+
+  SETINT(SERVICE_TRIGGER_DATA_TYPE_BINARY);
+  SETINT(SERVICE_TRIGGER_DATA_TYPE_STRING);
+  SETINT(SERVICE_TRIGGER_DATA_TYPE_LEVEL);
+  SETINT(SERVICE_TRIGGER_DATA_TYPE_KEYWORD_ANY);
+  SETINT(SERVICE_TRIGGER_DATA_TYPE_KEYWORD_ALL);
+
+  SETINT(SERVICE_START_REASON_DEMAND);
+  SETINT(SERVICE_START_REASON_AUTO);
+  SETINT(SERVICE_START_REASON_TRIGGER);
+  SETINT(SERVICE_START_REASON_RESTART_ON_FAILURE);
+  SETINT(SERVICE_START_REASON_DELAYEDAUTO);
+
+  SETINT(SERVICE_DYNAMIC_INFORMATION_LEVEL_START_REASON);
+
+  SETINT(SERVICE_LAUNCH_PROTECTED_NONE);
+  SETINT(SERVICE_LAUNCH_PROTECTED_WINDOWS);
+  SETINT(SERVICE_LAUNCH_PROTECTED_WINDOWS_LIGHT);
+  SETINT(SERVICE_LAUNCH_PROTECTED_ANTIMALWARE_LIGHT);
+
+  return 1;
+}

--- a/src/winsvc.h
+++ b/src/winsvc.h
@@ -1,3 +1,19 @@
+/*
+*  Copyright 2015 The Luvit Authors. All Rights Reserved.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*/
 #ifndef __WINSVC_H__
 #define __WINSVC_H__
 

--- a/src/winsvc.h
+++ b/src/winsvc.h
@@ -1,0 +1,7 @@
+#ifndef __WINSVC_H__
+#define __WINSVC_H__
+
+LUALIB_API int luaopen_winsvc(lua_State * const L);
+
+#endif /* __WINSVC_H__ */
+

--- a/src/winsvcaux.c
+++ b/src/winsvcaux.c
@@ -1,0 +1,57 @@
+#define LUA_LIB
+#include "lua.h"
+#include "lauxlib.h"
+
+#include <windows.h>
+
+static int lua_GetModuleFileName(lua_State *L)
+{
+  const char* handle = lua_tolstring(L, 1, NULL);
+  TCHAR name[MAX_PATH + 1];
+  DWORD ret = GetModuleFileName((HMODULE)handle, name, MAX_PATH + 1);
+  if (ret > 0)
+  {
+    lua_pushstring(L, name);
+    lua_pushnil(L);
+  }
+  else
+  {
+    lua_pushnil(L);
+    lua_pushinteger(L, GetLastError());
+  }
+  return 2;
+}
+
+static int lua_GetErrorString(lua_State *L)
+{
+  DWORD err = luaL_checkint(L, 1);
+  LPTSTR lpMsgBuf;
+
+  FormatMessage(
+    FORMAT_MESSAGE_ALLOCATE_BUFFER |
+    FORMAT_MESSAGE_FROM_SYSTEM |
+    FORMAT_MESSAGE_IGNORE_INSERTS,
+    NULL,
+    err,
+    MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+    (LPTSTR)&lpMsgBuf,
+    0, NULL);
+
+  lua_pushstring(L, lpMsgBuf);
+  LocalFree(lpMsgBuf);
+  return 1;
+}
+
+static const luaL_Reg winsvcauxlib[] = {
+    { "GetModuleFileName", lua_GetModuleFileName },
+    { "GetErrorString", lua_GetErrorString },
+    { NULL, NULL }
+};
+
+/*
+** Open Windows Service Aux library
+*/
+LUALIB_API int luaopen_winsvcaux(lua_State *L) {
+  luaL_register(L, "winsvcaux", winsvcauxlib);
+  return 1;
+}

--- a/src/winsvcaux.c
+++ b/src/winsvcaux.c
@@ -6,9 +6,9 @@
 
 static int lua_GetModuleFileName(lua_State *L)
 {
-  const char* handle = lua_tolstring(L, 1, NULL);
+  HMODULE handle = lua_touserdata(L, 1);
   TCHAR name[MAX_PATH + 1];
-  DWORD ret = GetModuleFileName((HMODULE)handle, name, MAX_PATH + 1);
+  DWORD ret = GetModuleFileName(handle, name, MAX_PATH + 1);
   if (ret > 0)
   {
     lua_pushstring(L, name);

--- a/src/winsvcaux.c
+++ b/src/winsvcaux.c
@@ -1,6 +1,20 @@
-#define LUA_LIB
-#include "lua.h"
-#include "lauxlib.h"
+/*
+*  Copyright 2015 The Luvit Authors. All Rights Reserved.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*/
+#include "luvi.h"
 
 #include <windows.h>
 

--- a/src/winsvcaux.h
+++ b/src/winsvcaux.h
@@ -1,3 +1,19 @@
+/*
+*  Copyright 2015 The Luvit Authors. All Rights Reserved.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*/
 #ifndef __WINSVCAUX_H__
 #define __WINSVCAUX_H__
 

--- a/src/winsvcaux.h
+++ b/src/winsvcaux.h
@@ -1,0 +1,7 @@
+#ifndef __WINSVCAUX_H__
+#define __WINSVCAUX_H__
+
+LUALIB_API int luaopen_winsvcaux(lua_State * const L);
+
+#endif /* __WINSVCAUX_H__ */
+


### PR DESCRIPTION
Add support for Windows Services while trying to stay true to the Windows Service Model.

The big differences between this and a Windows Service written in C is that the work done by the service happens in the context of the libUV thread.  StartServiceControlDispatcher is replaced with SpawnServiceControlDispatcher in order for it not to block the libUV thread.  Service control operations are handled by and replied to through lua callbacks for each supported service using libuv's uv_async_send.