### PR TITLE
small documentation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,11 +239,11 @@ Luvi Usage Instructions:
       # Run the new luvit binary
       ./luvit
 
-      # Run an app that layers on top of luvit (note trailing colon)
-      LUVI_APP=myapp: ./luvit
+      # Run an app that layers on top of luvit (note trailing semicolon)
+      LUVI_APP=myapp; ./luvit
 
       # Build your app
-      LUVI_APP=myapp: LUVI_TARGET=mybinary ./luvit
+      LUVI_APP=myapp; LUVI_TARGET=mybinary ./luvit
 ```
 
 You can run the sample repl app by doing:

--- a/src/lua/init.lua
+++ b/src/lua/init.lua
@@ -456,7 +456,7 @@ Usage:
       # Run the new luvit binary
       ./luvit
 
-      # Run an app that layers on top of luvit (note trailing colon)
+      # Run an app that layers on top of luvit (note trailing semicolon)
       "LUVI_APP=myapp;" ./luvit
 
       # Build your app


### PR DESCRIPTION
The README says to use a colon to bundle your app with luvit. however the usage from running luvi shows that it should be a semicolon.