### PR TITLE
Use Static Runtime Library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,21 @@ cmake_minimum_required(VERSION 2.8.9)
 
 project(luvi C)
 
+if(MSVC)
+  # Statically build against C runtime (use the right version for Release/Debug)
+  set(CompilerFlags
+        CMAKE_CXX_FLAGS
+        CMAKE_CXX_FLAGS_DEBUG
+        CMAKE_CXX_FLAGS_RELEASE
+        CMAKE_C_FLAGS
+        CMAKE_C_FLAGS_DEBUG
+        CMAKE_C_FLAGS_RELEASE
+        )
+  foreach(CompilerFlag ${CompilerFlags})
+    string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
+  endforeach()
+endif()
+
 exec_program(
     "git"
     ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
* Causes compile flags /MD to be replace with /MT for Release
* Causes compile flags /MDd to be replace with /MTd for Debug