### PR TITLE
Refactor luvi to not use environment variables (#80)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,7 @@ clean:
 test: luvi
 	rm -f test.bin
 	build/luvi samples/test.app -- 1 2 3 4
-	cd samples/test.app && ../../build/luvi -- 1 2 3 4 && cd -
-	build/luvi samples/test.app test.bin
+	build/luvi samples/test.app -o test.bin
 	./test.bin 1 2 3 4
 	rm -f test.bin
 install: luvi

--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,10 @@ clean:
 
 test: luvi
 	rm -f test.bin
-	LUVI_APP=samples/test.app build/luvi 1 2 3 4
-	LUVI_APP=samples/test.app LUVI_TARGET=test.bin build/luvi
-	LUVI_app= ./test.bin 1 2 3 4
+	build/luvi samples/test.app -- 1 2 3 4
+	cd samples/test.app && ../../build/luvi -- 1 2 3 4 && cd -
+	build/luvi samples/test.app test.bin
+	./test.bin 1 2 3 4
 	rm -f test.bin
 install: luvi
 	install -p build/luvi /usr/local/bin

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ vim myapp/main.lua
 # Run the app
 luvi myapp
 # Build the binary when done
-luvi myapp mybinary
+luvi myapp -o mybinary
 # Run the new self-contained binary
 ./mybinary
 # Deploy / Publish / Profit!
@@ -185,7 +185,7 @@ The following platforms are supported:
  - Windows (amd64)
  - FreeBSD 10.1 (amd64)
  - Raspberry PI Raspbian (armv6)
- - BeagleBone Black Debian (armv7)
+ - Raspberry PI 2 Raspbian (armv7)
  - Ubuntu 14.04 (x86_64)
  - OSX Yosemite (x86_64)
 
@@ -220,36 +220,32 @@ $ ls -lh build/luvi
 Run it to see usage information:
 
 ```sh
-$ luvi
+$ luvi -h
 
-Usage: luvi bundles... [-- extra args]
+Usage: luvi bundle+ [options] [-- extra args]
 
-    If target is omitted, the current working directory will be assumed.
-    Target is the path to a folder or zip file containing your app.
+  bundle            Path to directory or zip file containing bundle source.
+                    `bundle` can be specified multiple times to layer bundles
+                    on top of eachother.
+  --version         Show luvi version and compiled in options.
+  --output target   Build a luvi app by zipping the bundle and inserting luvi.
+  --help            Show this help file.
+  --                All args after this go to the luvi app itself.
 
-    Everything after a "--" argument will be passed through to the actual app.
+Examples:
 
-    You can pass in more than one target paths to folders and/or zip files to
-    be used as the bundle virtual file system.  These will be layered on top
-    of eachother. Items are searched in the paths from left to right.
+  # Run an app from disk, but pass in arguments
+  luvi path/to/app -- app args
 
-    Examples:
+  # Run from a app zip
+  luvi path/to/app.zip
 
-      # Run luvit directly from the filesystem (like a git checkout)
-      luvi luvit/app
+  # Run an app that layers on top of luvit
+  luvi path/to/app path/to/luvit
 
-      # Run the app in cwd, but pass some args
-      luvi -- my args
-
-      # Run an app that layers on top of luvit
-      luvi myapp luvit/app
-
-      # Run an app from disk, but pass in arguments
-      luvi myapp -- some args
-
-      # Zip an app and append to luvi as standalone executible
-      luvi myapp target
-      ./target some args
+  # Bundle an app with luvi to create standalone
+  luvi path/to/app -o target
+  ./target some args
 ```
 
 You can run the sample repl app by doing:

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ git init myapp
 # Write the app
 vim myapp/main.lua
 # Run the app
-LUVI_APP=myapp luvi
+luvi myapp
 # Build the binary when done
-LUVI_APP=myapp LUVI_TARGET=mybinary luvi
+luvi myapp mybinary
 # Run the new self-contained binary
 ./mybinary
 # Deploy / Publish / Profit!
@@ -220,86 +220,49 @@ $ ls -lh build/luvi
 Run it to see usage information:
 
 ```sh
-$ ./build/luvi
+$ luvi
 
-Luvi Usage Instructions:
+Usage: luvi bundles... [-- extra args]
 
-    Bare Luvi uses environment variables to configure its runtime parameters.
+    If target is omitted, the current working directory will be assumed.
+    Target is the path to a folder or zip file containing your app.
 
-    LUVI_APP is a colon separated list of paths to folders and/or zip files to
-             be used as the bundle virtual file system.  Items are searched in
-             the paths from left to right.
+    Everything after a "--" argument will be passed through to the actual app.
 
-    LUVI_TARGET is set when you wish to build a new binary instead of running
-                directly out of the raw folders.  Set this in addition to
-                LUVI_APP and luvi will build a new binary with the vfs embedded
-                inside as a single zip file at the end of the executable.
+    You can pass in more than one target paths to folders and/or zip files to
+    be used as the bundle virtual file system.  These will be layered on top
+    of eachother. Items are searched in the paths from left to right.
 
     Examples:
 
       # Run luvit directly from the filesystem (like a git checkout)
-      LUVI_APP=luvit/app ./build/luvi
+      luvi luvit/app
+
+      # Run the app in cwd, but pass some args
+      luvi -- my args
 
       # Run an app that layers on top of luvit
-      LUVI_APP=myapp:luvit/app ./build/luvi
+      luvi myapp luvit/app
 
-      # Build the luvit binary
-      LUVI_APP=luvit/app LUVI_TARGET=./luvit ./build/luvi
+      # Run an app from disk, but pass in arguments
+      luvi myapp -- some args
 
-      # Run the new luvit binary
-      ./luvit
-
-      # Run an app that layers on top of luvit (note trailing semicolon)
-      LUVI_APP=myapp; ./luvit
-
-      # Build your app
-      LUVI_APP=myapp; LUVI_TARGET=mybinary ./luvit
+      # Zip an app and append to luvi as standalone executible
+      luvi myapp target
+      ./target some args
 ```
 
 You can run the sample repl app by doing:
 
 ```sh
-LUVI_APP=samples/repl.app build/luvi
+build/luvi samples/repl.app
 ```
 
 Ot the test suite with:
 
 ```sh
-LUVI_APP=samples/test.app build/luvi
+build/luvi samples/test.app
 ```
-
-## Multiple Mains
-
-Luvi also has a feature where you can reuse the same binary bundle for
-multiple commands.  This is done by reading the value of `argv[0]` and looking
-for a main in `"main/" .. basename(args[0]) .. ".lua"`. before looking in
-`main.lua`.
-
-To use this you will typically create multiple mains in your bundle, one for
-each command you want to support.  Then when installing your app/utility,
-create a symlink to the main binary in the user's `$PATH` but named after each
-command.
-
-Here is an example that has two entry points, `add` and `subtract`
-
-```sh
-mkdir main
-vi main/add.lua
-vi main/subtract.lua
-```
-
-Then create symlinks somewhere points to luvi (or an old version of your
-binary)
-
-```sh
-ln -s luvi add
-ln -s luvi subtract
-```
-
-Then when you run theses symlinks, luvi will use the custom mains.
-
-All the previous rules about LUVI_APP and bundled zips in the binary still
-apply here.
 
 ## CMake Flags
 
@@ -337,4 +300,4 @@ cmake \
 ```
 
 
-[Prebuilt binaries]: https://github.com/luvit/luvi-binaries
+[Prebuilt binaries]: https://github.com/luvit/luvi/releases

--- a/make.bat
+++ b/make.bat
@@ -23,34 +23,22 @@ GOTO :end
 
 :test
 IF NOT EXIST luvi.exe CALL Make.bat
-SET LUVI_APP=samples\test.app
-luvi.exe
-SET LUVI_TARGET=test.exe
-luvi.exe
-SET "LUVI_APP="
-SET "LUVI_TARGET="
-test.exe
+luvi.exe samples\test.app 1 2 3 4
+luvi.exe samples\test.app -o test.exe
+test.exe 1 2 3 4
 DEL /Q test.exe
 GOTO :end
 
 :winsvc
 IF NOT EXIST luvi.exe CALL Make.bat
 DEL /Q winsvc.exe
-SET LUVI_APP=samples\winsvc.app
-SET LUVI_TARGET=winsvc.exe
-luvi.exe
-SET "LUVI_APP="
-SET "LUVI_TARGET="
+luvi.exe samples\winsvc.app -o winsvc.exe
 GOTO :end
 
 :repl
 IF NOT EXIST luvi.exe CALL Make.bat
 DEL /Q repl.exe
-SET LUVI_APP=samples\repl.app
-SET LUVI_TARGET=repl.exe
-luvi.exe
-SET "LUVI_APP="
-SET "LUVI_TARGET="
+luvi.exe samples/repl.app -o repl.exe
 GOTO :end
 
 

--- a/make.bat
+++ b/make.bat
@@ -23,7 +23,7 @@ GOTO :end
 
 :test
 IF NOT EXIST luvi.exe CALL Make.bat
-luvi.exe samples\test.app 1 2 3 4
+luvi.exe samples\test.app -- 1 2 3 4
 luvi.exe samples\test.app -o test.exe
 test.exe 1 2 3 4
 DEL /Q test.exe

--- a/samples/test.app/main.lua
+++ b/samples/test.app/main.lua
@@ -181,13 +181,11 @@ writer:add("data.json", '{"name":"Tim","age":32}\n', 9)
 writer:add("a/big/file.dat", string.rep("12345\n", 10000), 9)
 writer:add("main.lua", 'print(require("luvi").version)', 9)
 
-p(writer:finalize())
+p("zip bytes", #writer:finalize())
 
 
 local zlib
-if not pcall(function() zlib = require("zlib") end) then
-  print("zlib unavailable")
-else
+if pcall(function() zlib = require("zlib") end) then
   print("Testing zlib")
   p("zlib version", zlib.version())
   local tozblob = bundle.readfile("sonnet-133.txt")

--- a/src/lua/init.lua
+++ b/src/lua/init.lua
@@ -164,11 +164,11 @@ local function folderBundle(base)
     fd, err = uv.fs_open(path, "r", 0644)
     if not fd then return nil, err end
     stat, err = uv.fs_fstat(fd)
-    if not stat then return nil, err end
-    data, err = uv.fs_read(fd, stat.size, 0)
-    if not data then return nil, err end
+    if stat then
+      data, err = uv.fs_read(fd, stat.size, 0)
+    end
     uv.fs_close(fd)
-    return data
+    return data, err
   end
 
   return bundle

--- a/src/lua/init.lua
+++ b/src/lua/init.lua
@@ -19,6 +19,8 @@ limitations under the License.
 local os = require('ffi').os
 local env = require('env')
 local uv = require('uv')
+local luvi = require('luvi')
+local miniz = require('miniz')
 
 local getPrefix, splitPath, joinParts
 
@@ -124,426 +126,450 @@ local function pathJoin(...)
   return path
 end
 
+-- Bundle from folder on disk
+local function folderBundle(base)
+  local bundle = { base = base }
+
+  function bundle.stat(path)
+    path = pathJoin(base, "./" .. path)
+    local raw, err = uv.fs_stat(path)
+    if not raw then return nil, err end
+    return {
+      type = string.lower(raw.type),
+      size = raw.size,
+      mtime = raw.mtime,
+    }
+  end
+
+  function bundle.readdir(path)
+    path = pathJoin(base, "./" .. path)
+    local req, err = uv.fs_scandir(path)
+    if not req then
+      return nil, err
+    end
+
+    local files = {}
+    repeat
+      local ent = uv.fs_scandir_next(req)
+      if ent then
+        files[#files + 1] = ent.name
+      end
+    until not ent
+    return files
+  end
+
+  function bundle.readfile(path)
+    path = pathJoin(base, "./" .. path)
+    local fd, stat, data, err
+    fd, err = uv.fs_open(path, "r", 0644)
+    if not fd then return nil, err end
+    stat, err = uv.fs_fstat(fd)
+    if not stat then return nil, err end
+    data, err = uv.fs_read(fd, stat.size, 0)
+    if not data then return nil, err end
+    uv.fs_close(fd)
+    return data
+  end
+
+  return bundle
+end
+
+-- Insert a prefix into all bundle calls
+local function chrootBundle(bundle, prefix)
+  local bundleStat = bundle.stat
+  function bundle.stat(path)
+    return bundleStat(prefix .. path)
+  end
+  local bundleReaddir = bundle.readdir
+  function bundle.readdir(path)
+    return bundleReaddir(prefix .. path)
+  end
+  local bundleReadfile = bundle.readfile
+  function bundle.readfile(path)
+    return bundleReadfile(prefix .. path)
+  end
+end
+
+-- Use a zip file as a bundle
+local function zipBundle(base, zip)
+  local bundle = { base = base }
+
+  function bundle.stat(path)
+    path = pathJoin("./" .. path)
+    if path == "" then
+      return {
+        type = "directory",
+        size = 0,
+        mtime = 0
+      }
+    end
+    local err
+    local index = zip:locate_file(path)
+    if not index then
+      index, err = zip:locate_file(path .. "/")
+      if not index then return nil, err end
+    end
+    local raw = zip:stat(index)
+
+    return {
+      type = raw.filename:sub(-1) == "/" and "directory" or "file",
+      size = raw.uncomp_size,
+      mtime = raw.time,
+    }
+  end
+
+  function bundle.readdir(path)
+    path = pathJoin("./" .. path)
+    local index, err
+    if path == "" then
+      index = 0
+    else
+      path = path .. "/"
+      index, err = zip:locate_file(path )
+      if not index then return nil, err end
+      if not zip:is_directory(index) then
+        return nil, path .. " is not a directory"
+      end
+    end
+    local files = {}
+    for i = index + 1, zip:get_num_files() do
+      local filename = zip:get_filename(i)
+      if string.sub(filename, 1, #path) ~= path then break end
+      filename = filename:sub(#path + 1)
+      local n = string.find(filename, "/")
+      if n == #filename then
+        filename = string.sub(filename, 1, #filename - 1)
+        n = nil
+      end
+      if not n then
+        files[#files + 1] = filename
+      end
+    end
+    return files
+  end
+
+  function bundle.readfile(path)
+    path = pathJoin("./" .. path)
+    local index, err = zip:locate_file(path)
+    if not index then return nil, err end
+    return zip:extract(index)
+  end
+
+  -- Support zips with a single folder inserted at toplevel
+  local entries = bundle.readdir("")
+  if #entries == 1 and bundle.stat(entries[1]).type == "directory" then
+    chrootBundle(bundle, entries[1] .. '/')
+  end
+
+  return bundle
+end
+
+local function buildBundle(target, bundle)
+  local miniz = require('miniz')
+  target = pathJoin(uv.cwd(), target)
+  print("Creating new binary: " .. target)
+  local fd = assert(uv.fs_open(target, "w", 511)) -- 0777
+  local binSize
+  do
+    local source = uv.exepath()
+
+    local reader = miniz.new_reader(source)
+    if reader then
+      -- If contains a zip, find where the zip starts
+      binSize = reader:get_offset()
+    else
+      -- Otherwise just read the file size
+      binSize = uv.fs_stat(source).size
+    end
+    local fd2 = assert(uv.fs_open(source, "r", 384)) -- 0600
+    print("Copying initial " .. binSize .. " bytes from " .. source)
+    uv.fs_sendfile(fd, fd2, 0, binSize)
+    uv.fs_close(fd2)
+  end
+
+  local writer = miniz.new_writer()
+  local function copyFolder(path)
+    local files = bundle.readdir(path)
+    if not files then return end
+    for i = 1, #files do
+      local name = files[i]
+      if string.sub(name, 1, 1) ~= "." then
+        local child = pathJoin(path, name)
+        local stat = bundle.stat(child)
+        if stat.type == "directory" then
+          writer:add(child .. "/", "")
+          copyFolder(child)
+        elseif stat.type == "file" then
+          print("    " .. child)
+          writer:add(child, bundle.readfile(child), 9)
+        end
+      end
+    end
+  end
+  print("Zipping " .. bundle.base)
+  copyFolder("")
+  print("Writing zip file")
+  uv.fs_write(fd, writer:finalize(), binSize)
+  uv.fs_close(fd)
+  print("Done building " .. target)
+  return
+end
+
+-- Given a list of bundles, merge them into a single vfs.  Lower indexed items overshawdow later items.
+local function combinedBundle(bundles)
+  local bases = {}
+  for i = 1, #bundles do
+    bases[i] = bundles[i].base
+  end
+  local bundle = { base = table.concat(bases, ";") }
+
+  function bundle.stat(path)
+    local err
+    for i = 1, #bundles do
+      local stat
+      stat, err = bundles[i].stat(path)
+      if stat then return stat end
+    end
+    return nil, err
+  end
+
+  function bundle.readdir(path)
+    local has = {}
+    local files, err
+    for i = 1, #bundles do
+      local list
+      list, err = bundles[i].readdir(path)
+      if list then
+        for j = 1, #list do
+          local name = list[j]
+          if has[name] then
+            print("Warning multiple overlapping versions of " .. name)
+          else
+            has[name] = true
+            if files then
+              files[#files + 1] = name
+            else
+              files = { name }
+            end
+          end
+        end
+      end
+    end
+    if files then
+      return files
+    else
+      return nil, err
+    end
+  end
+
+  function bundle.readfile(path)
+    local err
+    for i = 1, #bundles do
+      local data
+      data, err = bundles[i].readfile(path)
+      if data then return data end
+    end
+    return nil, err
+  end
+
+  return bundle
+end
+
+local function makeBundle(app)
+  if app and (#app > 0) then
+    -- Split the string by ; leaving empty strings on ends
+    local parts = {}
+    local n = 1
+    for part in string.gmatch(app, '([^;]*)') do
+      if not parts[n] then
+        local path
+        if part == "" then
+          path = uv.exepath()
+        else
+          path = pathJoin(uv.cwd(), part)
+        end
+        local bundle
+        local zip = miniz.new_reader(path)
+        if zip then
+          bundle = zipBundle(path, zip)
+        else
+          local stat = uv.fs_stat(path)
+          if not stat or stat.type ~= "directory" then
+            print("ERROR: " .. path .. " is not a zip file or a folder")
+            return
+          end
+          bundle = folderBundle(path)
+        end
+        parts[n] = bundle
+      end
+      if part == "" then n = n + 1 end
+    end
+    if #parts == 1 then
+      return parts[1]
+    end
+    return combinedBundle(parts)
+  end
+  local path = uv.exepath()
+  local zip = miniz.new_reader(path)
+  if zip then return zipBundle(path, zip) end
+end
+
+local function commonBundle(bundle, args)
+
+  luvi.makeBundle = makeBundle
+  luvi.bundle = bundle
+
+  luvi.path = {
+    join = pathJoin,
+    getPrefix = getPrefix,
+    splitPath = splitPath,
+    joinparts = joinParts,
+  }
+
+  function bundle.action(path, action, ...)
+    -- If it's a real path, run it directly.
+    if uv.fs_access(path, "r") then return action(path) end
+    -- Otherwise, copy to a temporary folder and run from there
+    local data, err = bundle.readfile(path)
+    if not data then return nil, err end
+    local dir = assert(uv.fs_mkdtemp(pathJoin(tmpBase, "lib-XXXXXX")))
+    path = pathJoin(dir, path:match("[^/\\]+$"))
+    local fd = uv.fs_open(path, "w", 384) -- 0600
+    uv.fs_write(fd, data, 0)
+    uv.fs_close(fd)
+    local success, ret = pcall(action, path, ...)
+    uv.fs_unlink(path)
+    uv.fs_rmdir(dir)
+    assert(success, ret)
+    return ret
+  end
+
+  function bundle.register(name, path)
+    if not path then path = name + ".lua" end
+    package.preload[name] = function (...)
+      local lua = assert(bundle.readfile(path))
+      return assert(loadstring(lua, "bundle:" .. path))(...)
+    end
+  end
+
+  local mainPath = "main.lua"
+  local main = bundle.readfile(mainPath)
+
+  if not main then error("Missing " .. mainPath .. " in " .. bundle.base) end
+  _G.args = args
+
+  -- Auto-register the require system if present
+  local mainRequire
+  local stat = bundle.stat("deps/require.lua")
+  if stat and stat.type == "file" then
+    bundle.register('require', "deps/require.lua")
+    mainRequire = require('require')("bundle:" .. mainPath)
+  end
+
+  -- Auto-setup global p and libuv version of print
+  if mainRequire and bundle.stat("deps/pretty-print") or bundle.stat("deps/pretty-print.lua") then
+    _G.p = mainRequire('pretty-print').prettyPrint
+  end
+
+  local fn = assert(loadstring(main, "bundle:" .. mainPath))
+  if mainRequire then
+    setfenv(fn, setmetatable({
+      require = mainRequire
+    }, {
+      __index=_G
+    }))
+  end
+  return fn(unpack(args))
+
+end
+
+local function generateOptionsString()
+  local s = {}
+  for k, v in pairs(luvi.options) do
+    if type(v) == 'boolean' then
+      table.insert(s, k)
+    else
+      table.insert(s, string.format("%s: %s", k, v))
+    end
+  end
+  return table.concat(s, "\n")
+end
+
 return function(args)
 
-  local uv = require('uv')
-  local luvi = require('luvi')
-  local env = require('env')
-
-  -- Given a list of bundles, merge them into a single vfs.  Lower indexed items overshawdow later items.
-  local function combinedBundle(bundles)
-    local bases = {}
-    for i = 1, #bundles do
-      bases[i] = bundles[i].base
-    end
-    return {
-      base = table.concat(bases, " : "),
-      stat = function (path)
-        local err
-        for i = 1, #bundles do
-          local stat
-          stat, err = bundles[i].stat(path)
-          if stat then return stat end
-        end
-        return nil, err
-      end,
-      readdir = function (path)
-        local has = {}
-        local files, err
-        for i = 1, #bundles do
-          local list
-          list, err = bundles[i].readdir(path)
-          if list then
-            for j = 1, #list do
-              local name = list[j]
-              if has[name] then
-                print("Warning multiple overlapping versions of " .. name)
-              else
-                has[name] = true
-                if files then
-                  files[#files + 1] = name
-                else
-                  files = { name }
-                end
-              end
-            end
-          end
-        end
-        if files then
-          return files
-        else
-          return nil, err
-        end
-      end,
-      readfile = function (path)
-        local err
-        for i = 1, #bundles do
-          local data
-          data, err = bundles[i].readfile(path)
-          if data then return data end
-        end
-        return nil, err
-      end
-    }
+  -- First check for a bundled zip file appended to the executible
+  local path = uv.exepath()
+  local zip = miniz.new_reader(path)
+  if zip then
+    return commonBundle(zipBundle(path, zip), args)
   end
 
-  local function folderBundle(base)
-    return {
-      base = base,
-      stat = function (path)
-        path = pathJoin(base, "./" .. path)
-        local raw, err = uv.fs_stat(path)
-        if not raw then return nil, err end
-        return {
-          type = string.lower(raw.type),
-          size = raw.size,
-          mtime = raw.mtime,
-        }
-      end,
-      readdir = function (path)
-        path = pathJoin(base, "./" .. path)
-        local req, err = uv.fs_scandir(path)
-        if not req then return nil, err end
+  -- Look for luvi args with app args separated with "--"
+  local luviArgs = { [0] = args[0] }
+  local appArgs = { [0] = args[0] }
 
-        local files = {}
-        repeat
-          local ent = uv.fs_scandir_next(req)
-          if ent then files[#files + 1] = ent.name end
-        until not ent
-        return files
-      end,
-      readfile = function (path)
-        path = pathJoin(base, "./" .. path)
-        local fd, stat, data, err
-        fd, err = uv.fs_open(path, "r", 0644)
-        if not fd then return nil, err end
-        stat, err = uv.fs_fstat(fd)
-        if not stat then return nil, err end
-        data, err = uv.fs_read(fd, stat.size, 0)
-        if not data then return nil, err end
-        uv.fs_close(fd)
-        return data
-      end,
-    }
-  end
+  local list = luviArgs
 
-  local function chrootBundle(bundle, prefix)
-    local bundleStat = bundle.stat
-    function bundle.stat(path)
-      return bundleStat(prefix .. path)
-    end
-    local bundleReaddir = bundle.readdir
-    function bundle.readdir(path)
-      return bundleReaddir(prefix .. path)
-    end
-    local bundleReadfile = bundle.readfile
-    function bundle.readfile(path)
-      return bundleReadfile(prefix .. path)
-    end
-  end
-
-  local function zipBundle(base, zip)
-    local bundle = {
-      base = base,
-      stat = function (path)
-        path = pathJoin("./" .. path)
-        if path == "" then
-          return {
-            type = "directory",
-            size = 0,
-            mtime = 0
-          }
-        end
-        local err
-        local index = zip:locate_file(path)
-        if not index then
-          index, err = zip:locate_file(path .. "/")
-          if not index then return nil, err end
-        end
-        local raw = zip:stat(index)
-
-        return {
-          type = raw.filename:sub(-1) == "/" and "directory" or "file",
-          size = raw.uncomp_size,
-          mtime = raw.time,
-        }
-      end,
-      readdir = function (path)
-        path = pathJoin("./" .. path)
-        local index, err
-        if path == "" then
-          index = 0
-        else
-          path = path .. "/"
-          index, err = zip:locate_file(path )
-          if not index then return nil, err end
-          if not zip:is_directory(index) then
-            return nil, path .. " is not a directory"
-          end
-        end
-        local files = {}
-        for i = index + 1, zip:get_num_files() do
-          local filename = zip:get_filename(i)
-          if string.sub(filename, 1, #path) ~= path then break end
-          filename = filename:sub(#path + 1)
-          local n = string.find(filename, "/")
-          if n == #filename then
-            filename = string.sub(filename, 1, #filename - 1)
-            n = nil
-          end
-          if not n then
-            files[#files + 1] = filename
-          end
-        end
-        return files
-      end,
-      readfile = function (path)
-        path = pathJoin("./" .. path)
-        local index, err = zip:locate_file(path)
-        if not index then return nil, err end
-        return zip:extract(index)
-      end
-    }
-
-    -- Support zips with a single folder inserted at toplevel
-    local entries = bundle.readdir("")
-    if #entries == 1 and bundle.stat(entries[1]).type == "directory" then
-      chrootBundle(bundle, entries[1] .. '/')
-    end
-
-    return bundle
-  end
-
-  local function makeBundle(app)
-    local miniz = require('miniz')
-    if app and (#app > 0) then
-      -- Split the string by ; leaving empty strings on ends
-      local parts = {}
-      local n = 1
-      for part in string.gmatch(app, '([^;]*)') do
-        if not parts[n] then
-          local path
-          if part == "" then
-            path = uv.exepath()
-          else
-            path = pathJoin(uv.cwd(), part)
-          end
-          local bundle
-          local zip = miniz.new_reader(path)
-          if zip then
-            bundle = zipBundle(path, zip)
-          else
-            local stat = uv.fs_stat(path)
-            if not stat or stat.type ~= "directory" then
-              print("ERROR: " .. path .. " is not a zip file or a folder")
-              return
-            end
-            bundle = folderBundle(path)
-          end
-          parts[n] = bundle
-        end
-        if part == "" then n = n + 1 end
-      end
-      if #parts == 1 then
-        return parts[1]
-      end
-      return combinedBundle(parts)
-    end
-    local path = uv.exepath()
-    local zip = miniz.new_reader(path)
-    if zip then return zipBundle(path, zip) end
-  end
-
-  local function commonBundle(bundle)
-
-    function bundle.action(path, action, ...)
-      -- If it's a real path, run it directly.
-      if uv.fs_access(path, "r") then return action(path) end
-      -- Otherwise, copy to a temporary folder and run from there
-      local data, err = bundle.readfile(path)
-      if not data then return nil, err end
-      local dir = assert(uv.fs_mkdtemp(pathJoin(tmpBase, "lib-XXXXXX")))
-      path = pathJoin(dir, path:match("[^/\\]+$"))
-      local fd = uv.fs_open(path, "w", 384) -- 0600
-      uv.fs_write(fd, data, 0)
-      uv.fs_close(fd)
-      local success, ret = pcall(action, path, ...)
-      uv.fs_unlink(path)
-      uv.fs_rmdir(dir)
-      assert(success, ret)
-      return ret
-    end
-
-    luvi.bundle = bundle
-    luvi.makeBundle = makeBundle
-
-    luvi.path = {
-      join = pathJoin,
-      getPrefix = getPrefix,
-      splitPath = splitPath,
-      joinparts = joinParts,
-    }
-
-    bundle.register = function (name, path)
-      if not path then path = name + ".lua" end
-      package.preload[name] = function (...)
-        local lua = assert(bundle.readfile(path))
-        return assert(loadstring(lua, "bundle:" .. path))(...)
-      end
-    end
-
-    local mainPath, main
-    mainPath = env.get("LUVI_MAIN")
-    if mainPath then
-      main = bundle.readfile(mainPath)
+  for i = 1, #args do
+    local arg = args[i]
+    if arg == "--" then
+      list = appArgs
     else
-      local base = string.match(args[0], "[^/]*$")
-      if base then
-        mainPath = "main/" .. base .. ".lua"
-        main = bundle.readfile(mainPath)
-      end
-      if not main then
-        mainPath = "main.lua"
-        main = bundle.readfile(mainPath)
-      end
+      list[#list + 1] = arg
     end
-
-    if not main then error("Missing " .. mainPath .. " in " .. bundle.base) end
-    _G.args = args
-
-    -- Auto-register the require system if present
-    local mainRequire
-    local stat = bundle.stat("deps/require.lua")
-    if stat and stat.type == "file" then
-      bundle.register('require', "deps/require.lua")
-      mainRequire = require('require')("bundle:" .. mainPath)
-    end
-
-    -- Auto-setup global p and libuv version of print
-    if mainRequire and bundle.stat("deps/pretty-print") or bundle.stat("deps/pretty-print.lua") then
-      _G.p = mainRequire('pretty-print').prettyPrint
-    end
-
-    local fn = assert(loadstring(main, "bundle:" .. mainPath))
-    if mainRequire then
-      setfenv(fn, setmetatable({
-        require = mainRequire
-      }, {
-        __index=_G
-      }))
-    end
-    return fn(unpack(args))
-
   end
 
-  local function generateOptionsString()
-    local s = {}
-    for k, v in pairs(luvi.options) do
-      if type(v) == 'boolean' then
-        table.insert(s, k)
-      else
-        table.insert(s, string.format("%s: %s", k, v))
-      end
-    end
-    return table.concat(s, "\n")
+  path = table.remove(luviArgs, 1) or uv.cwd()
+  local target = table.remove(luviArgs, 1)
+
+  if #luviArgs > 0 then
+    error("Extra luvi arguments, did you mean app args using '--'?")
   end
 
-  local function buildBundle(target, bundle)
-    local miniz = require('miniz')
-    target = pathJoin(uv.cwd(), target)
-    print("Creating new binary: " .. target)
-    local fd = assert(uv.fs_open(target, "w", 511)) -- 0777
-    local binSize
-    do
-      local source = uv.exepath()
-
-      local reader = miniz.new_reader(source)
-      if reader then
-        -- If contains a zip, find where the zip starts
-        binSize = reader:get_offset()
-      else
-        -- Otherwise just read the file size
-        binSize = uv.fs_stat(source).size
-      end
-      local fd2 = assert(uv.fs_open(source, "r", 384)) -- 0600
-      print("Copying initial " .. binSize .. " bytes from " .. source)
-      uv.fs_sendfile(fd, fd2, 0, binSize)
-      uv.fs_close(fd2)
-    end
-
-    local writer = miniz.new_writer()
-    local function copyFolder(path)
-      local files = bundle.readdir(path)
-      if not files then return end
-      for i = 1, #files do
-        local name = files[i]
-        if string.sub(name, 1, 1) ~= "." then
-          local child = pathJoin(path, name)
-          local stat = bundle.stat(child)
-          if stat.type == "directory" then
-            writer:add(child .. "/", "")
-            copyFolder(child)
-          elseif stat.type == "file" then
-            print("    " .. child)
-            writer:add(child, bundle.readfile(child), 9)
-          end
-        end
-      end
-    end
-    print("Zipping " .. bundle.base)
-    copyFolder("")
-    print("Writing zip file")
-    uv.fs_write(fd, writer:finalize(), binSize)
-    uv.fs_close(fd)
-    print("Done building " .. target)
-    return
-  end
-
-  local bundle = makeBundle(env.get("LUVI_APP"))
+  local bundle = makeBundle(path)
   if bundle then
-    local target = env.get("LUVI_TARGET")
-    if not target or #target == 0 then return commonBundle(bundle) end
-    return buildBundle(target, bundle)
+    if bundle.readfile("main.lua") then
+      if target then return buildBundle(target, bundle) end
+      return commonBundle(bundle, appArgs)
+    else
+      print("No main.lua found in " .. path)
+    end
   end
+
   local prefix = string.format("%s %s", args[0], luvi.version)
   local options = generateOptionsString()
   local usage = [[
 
-Usage:
+Usage: $(LUVI) bundles... [-- extra args]
 
-    Bare Luvi uses environment variables to configure its runtime parameters.
+    If target is omitted, the current working directory will be assumed.
+    Target is the path to a folder or zip file containing your app.
 
-    LUVI_APP is a semicolon separated list of paths to folders and/or zip files to
-             be used as the bundle virtual file system.  Items are searched in
-             the paths from left to right.
+    Everything after a "--" argument will be passed through to the actual app.
 
-    LUVI_MAIN is the path to a custom `main.lua`.  It's path is relative to the bundle
-              root.  For example, a test runner might use `LUVI_MAIN=tests/run.lua`.
-
-    LUVI_TARGET is set when you wish to build a new binary instead of running
-                directly out of the raw folders.  Set this in addition to
-                LUVI_APP and luvi will build a new binary with the vfs embedded
-                inside as a single zip file at the end of the executable.
+    You can pass in more than one target paths to folders and/or zip files to
+    be used as the bundle virtual file system.  These will be layered on top
+    of eachother. Items are searched in the paths from left to right.
 
     Examples:
 
       # Run luvit directly from the filesystem (like a git checkout)
-      LUVI_APP=luvit/app $(LUVI)
+      $(LUVI) luvit/app
+
+      # Run the app in cwd, but pass some args
+      $(LUVI) -- my args
 
       # Run an app that layers on top of luvit
-      "LUVI_APP=myapp;luvit/app" $(LUVI)
+      $(LUVI) myapp luvit/app
 
-      # Build the luvit binary
-      LUVI_APP=luvit/app LUVI_TARGET=./luvit $(LUVI)
+      # Run an app from disk, but pass in arguments
+      $(LUVI) myapp -- some args
 
-      # Run the new luvit binary
-      ./luvit
+      # Zip an app and append to luvi as standalone executible
+      $(LUVI) myapp target
+      ./target some args
 
-      # Run an app that layers on top of luvit (note trailing semicolon)
-      "LUVI_APP=myapp;" ./luvit
-
-      # Build your app
-      "LUVI_APP=myapp;" LUVI_TARGET=mybinary ./luvit]]
+]]
   usage = string.gsub(usage, "%$%(LUVI%)", args[0])
   print(prefix)
   print()


### PR DESCRIPTION
I'm not set on the syntax.

The general idea is that luvi will no longer use environment variables to control it's behavior.  If it detects a zip file appended to itself, it will always run that zip and ignore all arguments (passing them directly to the app).

If there is no zip and it's a bare luvi, then it needs a way for the user to give it the following inputs:

 - one or more paths to luvi apps, can default to cwd if none are passed in
 - target to build binary
 - app-level arguments to be forwarded to main.

Also it would be nice to have things like `-h`, `--help`, `-v`, `--version`, etc.

I'm open to suggestions in the CLI parsing and behavior.