### PR TITLE
`make test` is needed to obtain luvi binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ If you're on windows, there is a `make.bat` file that works mostly like the unix
 ```sh
 cd luvi
 make
+make test
 ```
 
 When that's done you should have a shiny little binary `in build/luvi`.


### PR DESCRIPTION
doc is not synchronized with luvit.io install page. Could be nice to have only one place for doc editing.