### PR TITLE
Change library name from lua51 to luajit-5.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,9 +102,9 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
 endif()
 
 if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
-  target_link_libraries(luvi uv lua51 luv rt ${EXTRA_LIBS})
+  target_link_libraries(luvi uv luajit-5.1 luv rt ${EXTRA_LIBS})
 else()
-  target_link_libraries(luvi uv lua51 luv ${EXTRA_LIBS})
+  target_link_libraries(luvi uv luajit-5.1 luv ${EXTRA_LIBS})
 endif()
 
 ###############################################################################


### PR DESCRIPTION
With commit https://github.com/luvit/luv/commit/c6ce627f404a38044b475b3000139768c36fbb02 the library name for the luajit library is renamed from lua51 to luajit-5.1. Use this name for linking with luajit.