### PR TITLE
 Set LUVI_VERSION manually

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 2.8.9)
 
 project(luvi C)
 
+set(LUVI_VERSION_MAJOR 2)
+set(LUVI_VERSION_MINOR 0)
+set(LUVI_VERSION_PATCH 9)
+set(LUVI_VERSION ${LUVI_VERSION_MAJOR}.${LUVI_VERSION_MINOR}.${LUVI_VERSION_PATCH})
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 if(MSVC)
@@ -18,12 +23,6 @@ if(MSVC)
     string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
   endforeach()
 endif()
-
-exec_program(
-    "git"
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ARGS "describe" "--tags"
-    OUTPUT_VARIABLE LUVI_VERSION)
 
 option(WithSharedLibluv "Shared or Static libluv" OFF)
 option(WithOpenSSL "Include OpenSSL" OFF)


### PR DESCRIPTION
Do not use git to set `LUVI_VERSION` as it may be not available on the build
system, e.g. by just downloading the github source tarball.

Furthermore, if luvi is build by Buildroot cloned with git, `git describe` does
return the tag from Buildroot as luvi version which is obviously wrong.