### PR TITLE
LuaJITAddExecutable: pass LJ_BYTECODE_OPTS as bytecode options to LuaJIT

### DIFF
--- a/cmake/Modules/LuaJITAddExecutable.cmake
+++ b/cmake/Modules/LuaJITAddExecutable.cmake
@@ -9,6 +9,9 @@
 
 MACRO(LUAJIT_add_custom_commands luajit_target)
   SET(TARGET_ARCH $ENV{TARGET_ARCH})
+  IF(TARGET_ARCH)
+    SET(LJ_BYTECODE_OPTS ${LJ_BYTECODE_OPTS} -a ${TARGET_ARCH})
+  ENDIF(TARGET_ARCH)
   SET(LUA_PATH $ENV{LUA_PATH})
   SET(target_srcs "")
   FOREACH(file ${ARGN})
@@ -27,7 +30,7 @@ MACRO(LUAJIT_add_custom_commands luajit_target)
         OUTPUT ${generated_file}
         MAIN_DEPENDENCY ${source_file}
         COMMAND "LUA_PATH=${LUA_PATH}" luajit
-        ARGS -b -a ${TARGET_ARCH}
+        ARGS -b ${LJ_BYTECODE_OPTS}
           ${source_file}
           ${generated_file}
         COMMENT "Building Luajitted ${source_file}: ${generated_file}"


### PR DESCRIPTION
Always passing the `-a` option as a bytecode option has a severe drawback: we need to pass always a target architecture to LuaJIT and cannot use the native build used by LuaJIT if no `-a` is passed.

Fix this by passing the `-a` option conditionally by using the variable `LJ_BYTECODE_OPTS`. This also allows as to pass other bytecode options through the environment.