### PR TITLE
cmake: should always include LuaJITAddExectuable module.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,6 @@ if (WithSharedLibluv)
   if (LIBUV_FOUND)
     include_directories(${LIBUV_INCLUDE_DIR})
   endif (LIBUV_FOUND)
-  include(LuaJITAddExecutable)
   set(LUVI_LIBRARIES ${LIBLUV_LIBRARIES} ${LUAJIT_LIBRARIES} ${LIBUV_LIBRARIES})
 else (WithSharedLibluv)
   # Build luv as static library insteas as module
@@ -126,6 +125,8 @@ endif()
 if(UNIX)
   add_definitions(-Wall)
 endif()
+
+include(LuaJITAddExecutable)
 
 luajit_add_executable(luvi
   ${winsvc}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,8 @@ option(WithPackageBUNDLE "Build OSX bundle." OFF)
 
 find_package(Threads)
 
+include(LuaJITAddExecutable)
+
 if (WithSharedLibluv)
   # Building against a shared libluv provides that libluajit and libuv exists
   find_package(Libluv)
@@ -125,8 +127,6 @@ endif()
 if(UNIX)
   add_definitions(-Wall)
 endif()
-
-include(LuaJITAddExecutable)
 
 luajit_add_executable(luvi
   ${winsvc}


### PR DESCRIPTION
The `include(LuaJITAddExecutable)` at [line 88](https://github.com/luvit/luvi/blob/master/CMakeLists.txt#L88) was encolsed by `if (WithSharedLibluv)` at (line 74](https://github.com/luvit/luvi/blob/master/CMakeLists.txt#L74) but `luajit_add_executable` is used at [line 130](https://github.com/luvit/luvi/blob/master/CMakeLists.txt#L130) without conditions.