### PR TITLE
Add support for zlib compression with miniz (#163)

### DIFF
--- a/deps/miniz.c
+++ b/deps/miniz.c
@@ -138,7 +138,7 @@
 //#define MINIZ_NO_ARCHIVE_WRITING_APIS
 
 // Define MINIZ_NO_ZLIB_APIS to remove all ZLIB-style compression/decompression API's.
-#define MINIZ_NO_ZLIB_APIS
+//#define MINIZ_NO_ZLIB_APIS
 
 // Define MINIZ_NO_ZLIB_COMPATIBLE_NAME to disable zlib names, to prevent conflicts against stock zlib.
 #define MINIZ_NO_ZLIB_COMPATIBLE_NAMES

--- a/src/lminiz.c
+++ b/src/lminiz.c
@@ -222,7 +222,7 @@ static int lmz_writer_finalize(lua_State *L) {
 static int lmz_deflator_init(lua_State* L) {
   int level = luaL_optint(L, 1, MZ_DEFAULT_COMPRESSION);
   if (level < MZ_DEFAULT_COMPRESSION || level > MZ_BEST_COMPRESSION) {
-      luaL_error(L, "Compression level must be between -1 and 9");
+    luaL_error(L, "Compression level must be between -1 and 9");
   }
   lmz_stream_t* stream = lua_newuserdata(L, sizeof(*stream));
   mz_streamp miniz_stream = &(stream->stream);


### PR DESCRIPTION
This allows users of luvi to use zlib compression without the zlib module, meaning that it is technically no longer necessary.

This has been tested on Debian buster (current testing) on a 64-bit AMD processor, where it appears to work correctly. I expect it to work correctly on all current targets.

I believe I have followed the style of code in my edits, though I will gladly fix any issues that are pointed out.

The API looks something like this, using the example of a deflator:
```lua
local miniz = require("miniz")
local deflator = miniz.new_deflator() -- optionally accepts the compression level to use
local deflated, err, partial = deflator:deflate("input text") -- optionally accepts a flush mode to use
-- if there was an error, deflate returns nil, the error that occured, as well as any partial data it managed to compress before an error occured.
print("Deflated data:")
print(deflated or partial)
if err then
    print("Error:")
    print(err)
end
```