### PR TITLE
Fix passing async handles to threads

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -62,14 +62,21 @@ static lua_State* vm_acquire(){
   // Add in the lua standard and compat libraries
   luvi_openlibs(L);
 
-  // Get package.preload so we can store builtins in it.
+  // Get package.loaded so that we can load modules
   lua_getglobal(L, "package");
+  lua_getfield(L, -1, "loaded");
+
+  // load luv into uv in advanced so that the metatables for async work.
+  lua_pushcfunction(L, luaopen_luv);
+  lua_call(L, 0, 1);
+  lua_setfield(L, -2, "uv");
+  
+  // remove package.loaded
+  lua_remove(L, -1);
+
+  // Get package.preload so we can store builtins in it.
   lua_getfield(L, -1, "preload");
   lua_remove(L, -2); // Remove package
-
-  // Store uv module definition at preload.uv
-  lua_pushcfunction(L, luaopen_luv);
-  lua_setfield(L, -2, "uv");
 
   lua_pushcfunction(L, luaopen_env);
   lua_setfield(L, -2, "env");

--- a/src/main.c
+++ b/src/main.c
@@ -66,7 +66,7 @@ static lua_State* vm_acquire(){
   lua_getglobal(L, "package");
   lua_getfield(L, -1, "loaded");
 
-  // load luv into uv in advanced so that the metatables for async work.
+  // load luv into uv in advance so that the metatables for async work.
   lua_pushcfunction(L, luaopen_luv);
   lua_call(L, 0, 1);
   lua_setfield(L, -2, "uv");


### PR DESCRIPTION
Luvi overrides the vm_acquire callback used by luv to construct the childstate, but it only puts the call to luv_open into package.preload, it doesn't actually load luv. So when luv tried to unmarshal the userdata in the arguments, it looked in the registry for the metatables for the handles, but they weren't set so the userdata got a nil metatable preventing them from being used.

This change makes luvi load luv at lua_State creation instead of just preloading it so that the metatables and type information for luv handles are present when luv thread operations attempt to transfer an async handle across threads.