### PR TITLE
Cleanup Static OpenSSL Build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "deps/lua-openssl"]
 	path = deps/lua-openssl
 	url = https://github.com/zhaozg/lua-openssl.git
-[submodule "deps/openssl"]
-	path = deps/openssl
-	url = https://github.com/luvit/openssl.git
 [submodule "deps/luv"]
 	path = deps/luv
 	url = https://github.com/luvit/luv.git

--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,10 @@ endif
 ifndef NPROCS
 ifeq ($(OS),Linux)
 	NPROCS:=$(shell grep -c ^processor /proc/cpuinfo)
-	SHAREDSSL=ON
+	SHAREDSSL?=ON
 else ifeq ($(OS),Darwin)
 	NPROCS:=$(shell sysctl hw.ncpu | awk '{print $$2}')
-	SHAREDSSL=OFF
+	SHAREDSSL?=OFF
 endif
 endif
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2015
+image: Visual Studio 2017
 configuration: Release
 
 environment:

--- a/deps/lua-openssl.cmake
+++ b/deps/lua-openssl.cmake
@@ -4,6 +4,7 @@ if(DEFINED ENV{LUA_OPENSSL_DIR})
 endif()
 
 include_directories(
+  ${CMAKE_BINARY_DIR}/include
   ${LUA_OPENSSL_DIR}/deps/auxiliar
   ${LUA_OPENSSL_DIR}/deps/lua-compat
   ${LUA_OPENSSL_DIR}/src
@@ -66,13 +67,13 @@ add_library(lua_openssl
   ${LUA_OPENSSL_DIR}/src/xstore.c
 )
 
-set_target_properties(lua_openssl PROPERTIES
-    COMPILE_FLAGS "-DLUA_LIB")
+set_target_properties(lua_openssl PROPERTIES COMPILE_FLAGS "-DLUA_LIB")
 
 if (WithSharedOpenSSL)
   target_link_libraries(lua_openssl ssl crypto)
 else (WithSharedOpenSSL)
-  target_link_libraries(lua_openssl openssl)
+  add_dependencies(lua_openssl openssl)
+  target_link_libraries(lua_openssl openssl_ssl openssl_crypto)
 endif (WithSharedOpenSSL)
 
 set(EXTRA_LIBS ${EXTRA_LIBS} lua_openssl)

--- a/deps/openssl.cmake
+++ b/deps/openssl.cmake
@@ -9,8 +9,53 @@ if (WithSharedOpenSSL)
   list(APPEND LIB_LIST ${OPENSSL_LIBRARIES})
 else (WithSharedOpenSSL)
   message("Enabling Static OpenSSL")
-  include(deps/openssl/openssl.cmake)
-  list(APPEND LIB_LIST openssl)
+  include(ExternalProject)
+
+  set(OPENSSL_CONFIG_OPTIONS no-unit-test no-shared no-asm no-stdio no-idea no-mdc2 no-rc5 --prefix=${CMAKE_BINARY_DIR})
+
+  if(WIN32)
+      if("${CMAKE_GENERATOR}" MATCHES "(Win64|IA64)")
+        set(OPENSSL_CONFIGURE_COMMAND perl ./Configure VC-WIN64A ${OPENSSL_CONFIG_OPTIONS})
+      else()
+        set(OPENSSL_CONFIGURE_COMMAND perl ./Configure VC-WIN32 ${OPENSSL_CONFIG_OPTIONS})
+      endif()
+      set(OPENSSL_BUILD_COMMAND nmake)
+  else()
+      set(OPENSSL_CONFIGURE_COMMAND ./config ${OPENSSL_CONFIG_OPTIONS})
+      set(OPENSSL_BUILD_COMMAND make)
+  endif()
+  
+  ExternalProject_Add(openssl
+      PREFIX            openssl
+      URL               https://www.openssl.org/source/openssl-1.1.0i.tar.gz
+      URL_HASH          SHA256=ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99
+      BUILD_IN_SOURCE   YES
+      BUILD_COMMAND     ${OPENSSL_BUILD_COMMAND}
+      CONFIGURE_COMMAND ${OPENSSL_CONFIGURE_COMMAND}
+      INSTALL_COMMAND   ""
+      TEST_COMMAND      ""
+      UPDATE_COMMAND    ""
+      UPDATE_DISCONNECTED YES
+  )
+  
+  set(OPENSSL_DIR ${CMAKE_BINARY_DIR}/openssl/src/openssl)
+  set(OPENSSL_INCLUDE ${OPENSSL_DIR}/include)
+  
+  if(WIN32)
+    set(OPENSSL_LIB_CRYPTO ${OPENSSL_DIR}/libcrypto.lib)
+    set(OPENSSL_LIB_SSL ${OPENSSL_DIR}/libssl.lib)
+  else()
+    set(OPENSSL_LIB_CRYPTO ${OPENSSL_DIR}/libcrypto.a)
+    set(OPENSSL_LIB_SSL ${OPENSSL_DIR}/libssl.a)
+  endif()
+  
+  add_library(openssl_ssl STATIC IMPORTED)
+  set_target_properties(openssl_ssl PROPERTIES IMPORTED_LOCATION ${OPENSSL_LIB_SSL})
+  add_library(openssl_crypto STATIC IMPORTED)
+  set_target_properties(openssl_crypto PROPERTIES IMPORTED_LOCATION ${OPENSSL_LIB_CRYPTO})
+  
+  include_directories(${OPENSSL_INCLUDE})
+  list(APPEND LIB_LIST openssl_ssl openssl_crypto)
 endif (WithSharedOpenSSL)
 
 add_definitions(-DWITH_OPENSSL)


### PR DESCRIPTION
Migrates to a portable static build of OpenSSL using CMake's ExternalProject_Add. Tested on Windows, Linux, and OSX.

Bumps to Openssl 1.1.0i.

To Test:
```
# checkout this branch
# make SHAREDSSL=false regular-asm
# make
# build/luvi --version
# ldd build/luvi
```

TODO
- [x] Windows Testing