### PR TITLE
initial pass at multiplatform builds

### DIFF
--- a/deps/openssl.cmake
+++ b/deps/openssl.cmake
@@ -22,7 +22,7 @@ else (WithSharedOpenSSL)
       set(OPENSSL_BUILD_COMMAND nmake)
   else()
       set(OPENSSL_CONFIGURE_COMMAND ./config ${OPENSSL_CONFIG_OPTIONS})
-      set(OPENSSL_BUILD_COMMAND make -j6)
+      set(OPENSSL_BUILD_COMMAND make)
   endif()
   
   ExternalProject_Add(openssl

--- a/deps/openssl.cmake
+++ b/deps/openssl.cmake
@@ -22,13 +22,14 @@ else (WithSharedOpenSSL)
       set(OPENSSL_BUILD_COMMAND nmake)
   else()
       set(OPENSSL_CONFIGURE_COMMAND ./config ${OPENSSL_CONFIG_OPTIONS})
-      set(OPENSSL_BUILD_COMMAND make)
+      set(OPENSSL_BUILD_COMMAND make -j6)
   endif()
   
   ExternalProject_Add(openssl
       PREFIX            openssl
       URL               https://www.openssl.org/source/openssl-1.1.0i.tar.gz
       URL_HASH          SHA256=ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99
+      LOG_BUILD         ON
       BUILD_IN_SOURCE   YES
       BUILD_COMMAND     ${OPENSSL_BUILD_COMMAND}
       CONFIGURE_COMMAND ${OPENSSL_CONFIGURE_COMMAND}

--- a/packaging/Dockerfile.in
+++ b/packaging/Dockerfile.in
@@ -1,0 +1,8 @@
+from multiarch/ubuntu-core:@@ARCH@@-bionic
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get -y upgrade
+RUN apt-get install -y build-essential cmake git gzip
+
+WORKDIR /src

--- a/packaging/docker-build.sh
+++ b/packaging/docker-build.sh
@@ -3,32 +3,36 @@
 set -eou pipefail
 set -x
 
-BUILD_TYPE=${1:-regular-asm}
-BUILD_NAME=${2:-regular}
-
-if [[ $BUILD_TYPE = *"tiny"* ]]; then
-  BUILD_NAME=tiny
-fi
-
 cd $(dirname $0)
-echo "Build Type: ${BUILD_TYPE}"
 
 build() {
   arch=$1
+  build_name=$2
   tmpdir=$(mktemp -d)
   image_name=luvi-builder-$arch
+
+  echo "Building: $arch $build_name"
 
   sed "s:@@ARCH@@:$arch:g" Dockerfile.in > $tmpdir/Dockerfile
   docker build --rm -t $image_name -f $tmpdir/Dockerfile .
   docker run -v $PWD/..:/src $image_name make clean
-  docker run -v $PWD/..:/src -e SHAREDSSL=false $image_name make $BUILD_TYPE luvi
-  cp -f ../build/luvi ../packaging/luvi-$BUILD_NAME-linux_$arch
+  docker run -v $PWD/..:/src -e SHAREDSSL=false $image_name make $build_name luvi
+
+  if [[ "$build_name" == "regular-asm" ]]; then
+    build_name="regular"
+  fi
+
+  cp -f ../build/luvi ../packaging/luvi-$build_name-Linux_$arch
+
+  rm -rf $tmpdir
 }
 
 docker run --rm --privileged multiarch/qemu-user-static:register --reset
 
 ARCHS=("armhf" "x86" "x86_64")
+BUILD_NAMES=("tiny" "regular-asm")
 for i in "${!ARCHS[@]}"; do
-  arch=${ARCHS[$i]}
-  build $arch
+  for j in "${!BUILD_NAMES[@]}"; do
+    build ${ARCHS[$i]} ${BUILD_NAMES[$j]}
+  done
 done

--- a/packaging/docker-build.sh
+++ b/packaging/docker-build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -eou pipefail
+set -x
+
+BUILD_TYPE=${1:-regular-asm}
+BUILD_NAME=${2:-regular}
+
+if [[ $BUILD_TYPE = *"tiny"* ]]; then
+  BUILD_NAME=tiny
+fi
+
+cd $(dirname $0)
+echo "Build Type: ${BUILD_TYPE}"
+
+build() {
+  arch=$1
+  tmpdir=$(mktemp -d)
+  image_name=luvi-builder-$arch
+
+  sed "s:@@ARCH@@:$arch:g" Dockerfile.in > $tmpdir/Dockerfile
+  docker build --rm -t $image_name -f $tmpdir/Dockerfile .
+  docker run -v $PWD/..:/src $image_name make clean
+  docker run -v $PWD/..:/src -e SHAREDSSL=false $image_name make $BUILD_TYPE luvi
+  cp -f ../build/luvi ../packaging/luvi-$BUILD_NAME-linux_$arch
+}
+
+docker run --rm --privileged multiarch/qemu-user-static:register --reset
+
+ARCHS=("armhf" "x86" "x86_64")
+for i in "${!ARCHS[@]}"; do
+  arch=${ARCHS[$i]}
+  build $arch
+done


### PR DESCRIPTION
~This is still a WIP.~

We can emulate the build architecture environments with Linux, docker, and qemu-static-$arch binaries.

```
Host machine:
 docker run --rm --privileged multiarch/qemu-user-static:register --reset
 install qemu-static-binaries
```

Then we can run [multiarch Ubuntu docker images ](https://hub.docker.com/r/multiarch/ubuntu-core/tags/) via:

```
docker run -ti multiarch/ubuntu-core:armhf-bionic bash
```

The general idea is to build luvi within each emulated docker container.

_**I am not sure when I will get back to PR, but if someone is inspired feel free to PR a full solution**_

Resources:

[Cross-Building-and-Running-Multi-Arch-Docker-Images](https://www.ecliptik.com/Cross-Building-and-Running-Multi-Arch-Docker-Images/)