### PR TITLE
openssl: use the default build command

### DIFF
--- a/deps/openssl.cmake
+++ b/deps/openssl.cmake
@@ -19,10 +19,8 @@ else (WithSharedOpenSSL)
       else()
         set(OPENSSL_CONFIGURE_COMMAND perl ./Configure VC-WIN32 ${OPENSSL_CONFIG_OPTIONS})
       endif()
-      set(OPENSSL_BUILD_COMMAND nmake)
   else()
       set(OPENSSL_CONFIGURE_COMMAND ./config ${OPENSSL_CONFIG_OPTIONS})
-      set(OPENSSL_BUILD_COMMAND make)
   endif()
   
   ExternalProject_Add(openssl
@@ -30,7 +28,6 @@ else (WithSharedOpenSSL)
       URL               https://www.openssl.org/source/openssl-1.1.0i.tar.gz
       URL_HASH          SHA256=ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99
       BUILD_IN_SOURCE   YES
-      BUILD_COMMAND     ${OPENSSL_BUILD_COMMAND}
       CONFIGURE_COMMAND ${OPENSSL_CONFIGURE_COMMAND}
       INSTALL_COMMAND   ""
       TEST_COMMAND      ""

--- a/deps/openssl.cmake
+++ b/deps/openssl.cmake
@@ -12,6 +12,7 @@ else (WithSharedOpenSSL)
   include(ExternalProject)
 
   set(OPENSSL_CONFIG_OPTIONS no-unit-test no-shared no-asm no-stdio no-idea no-mdc2 no-rc5 --prefix=${CMAKE_BINARY_DIR})
+  set(OPENSSL_BUILD_COMMAND ${MAKE})
 
   if(WIN32)
       if("${CMAKE_GENERATOR}" MATCHES "(Win64|IA64)")
@@ -28,6 +29,7 @@ else (WithSharedOpenSSL)
       URL               https://www.openssl.org/source/openssl-1.1.0i.tar.gz
       URL_HASH          SHA256=ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99
       BUILD_IN_SOURCE   YES
+      BUILD_COMMAND     ${OPENSSL_BUILD_COMMAND}
       CONFIGURE_COMMAND ${OPENSSL_CONFIGURE_COMMAND}
       INSTALL_COMMAND   ""
       TEST_COMMAND      ""


### PR DESCRIPTION
CMake will pass down the default build commands including any parallelization by not setting the build command.