### PR TITLE
luvi executable needs to export symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,7 @@ if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
 endif()
 
 target_link_libraries(luvi ${LUVI_LIBRARIES} ${EXTRA_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+set_target_properties(luvi PROPERTIES ENABLE_EXPORTS ON)
 
 ###############################################################################
 ## Installation Targets


### PR DESCRIPTION
Running luvi is broken when building with CMake 3.12:

```
[string "return require('init')(...)"]:1: module 'init' not found:
	no field package.preload['init']
	no file './init.lua'
	no file '/usr/share/luajit-2.0.5/init.lua'
	no file '/usr/local/share/lua/5.1/init.lua'
	no file '/usr/local/share/lua/5.1/init/init.lua'
	no file '/usr/share/lua/5.1/init.lua'
	no file '/usr/share/lua/5.1/init/init.lua'
	no file './init.so'
	no file '/usr/local/lib/lua/5.1/init.so'
	no file '/usr/lib/lua/5.1/init.so'
	no file '/usr/local/lib/lua/5.1/loadall.so'
```

Looking at link.txt for the luvi executable shows that `-rdynamic` is not set anymore in CMake 3.12. This has the effect, that symbols are missing in the `.dynsym` section.

Therefore, set `ENABLE_EXPORTS` to true which sets `-rdynamic` explicitly.

Fixes: #184