### PR TITLE
Fix checking if environment variable is defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ else (WithSharedLibluv)
 endif (WithSharedLibluv)
 
 set(LUA_COMPAT53_DIR deps/luv/deps/lua-compat-5.3)
-if($ENV{LUA_COMPAT53_DIR})
+if(DEFINED ENV{LUA_COMPAT53_DIR})
   set(LUA_COMPAT53_DIR $ENV{LUA_COMPAT53_DIR})
 endif()
 include_directories(${LUA_COMPAT53_DIR})


### PR DESCRIPTION
The correct way to check if an environment variable is defined is to use `if(DEFINED ENV{})`.

See: https://cmake.org/pipermail/cmake/2011-October/046704.html