### PR TITLE
Update lua-openssl to 0.7.4

### DIFF
--- a/deps/lua-openssl.cmake
+++ b/deps/lua-openssl.cmake
@@ -54,7 +54,6 @@ add_library(lua_openssl
   ${LUA_OPENSSL_DIR}/src/private.h
   ${LUA_OPENSSL_DIR}/src/rsa.c
   ${LUA_OPENSSL_DIR}/src/sk.h
-  ${LUA_OPENSSL_DIR}/src/sm2.c
   ${LUA_OPENSSL_DIR}/src/srp.c
   ${LUA_OPENSSL_DIR}/src/ssl.c
   ${LUA_OPENSSL_DIR}/src/th-lock.c


### PR DESCRIPTION
Fixes build error:

```
deps/lua-openssl/src/sm2.c:6:12: fatal error: openssl/sm2.h: No such file or directory
 #  include <openssl/sm2.h>
```