### PR TITLE
Fix __pfnDliFailureHook2 redefinition on MSVC versions < 2015 Update 3

### DIFF
--- a/src/luvi_renamed.c
+++ b/src/luvi_renamed.c
@@ -1,8 +1,10 @@
 #include "windows.h"
 #include "delayimp.h"
 FARPROC WINAPI LoadFailureHook(unsigned dliNotify, PDelayLoadInfo pdli);
+#if _MSC_FULL_VER >= 190024210 // MSVC 2015 Update 3
 #ifndef DELAYIMP_INSECURE_WRITABLE_HOOKS
 const
+#endif
 #endif
 extern PfnDliHook __pfnDliFailureHook2 = LoadFailureHook;
 


### PR DESCRIPTION
The const was added to __pfnDliFailureHook2 in MSVC 2015 Update 3, so any compilers before that shouldn't define it as const