### PR TITLE
Revert "Use shared openssl on Linux (#178)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ ifdef WITHOUT_AMALG
 endif
 
 WITH_SHARED_LIBLUV ?= OFF
+SHAREDSSL ?= OFF
 
 CMAKE_FLAGS += \
 	-DWithSharedLibluv=$(WITH_SHARED_LIBLUV)
@@ -41,10 +42,8 @@ endif
 ifndef NPROCS
 ifeq ($(OS),Linux)
 	NPROCS:=$(shell grep -c ^processor /proc/cpuinfo)
-	SHAREDSSL?=ON
 else ifeq ($(OS),Darwin)
 	NPROCS:=$(shell sysctl hw.ncpu | awk '{print $$2}')
-	SHAREDSSL?=OFF
 endif
 endif
 


### PR DESCRIPTION
This reverts commit 83f187174147d663a443789e7b102a057e8f25ce.

See this comment: https://github.com/luvit/luvi/issues/178#issuecomment-470342437

The standard `get-lit` command also fails for me on my Linux machine (Ubuntu 16.04):

```
./luvi: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by ./luvi)
./luvi: /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1: version `OPENSSL_1_1_1' not found (required by ./luvi)
```