### PR TITLE
Fix WithOpenSSLASM option being ignored

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,10 @@ environment:
 matrix:
   fast_finish: true
 
+install:
+  - choco install nasm
+  - set PATH="C:\Program Files\NASM";%PATH%
+
 build_script:
  - git submodule update --init --recursive
  - Make.bat %BUILD_TYPE%
@@ -21,3 +25,7 @@ test_script:
 artifacts:
  - path: luvi.exe
 
+cache:
+  - C:\ProgramData\chocolatey\bin -> appveyor.yml
+  - C:\ProgramData\chocolatey\lib -> appveyor.yml
+  - C:\Program Files\NASM -> appveyor.yml

--- a/deps/openssl.cmake
+++ b/deps/openssl.cmake
@@ -11,7 +11,10 @@ else (WithSharedOpenSSL)
   message("Enabling Static OpenSSL")
   include(ExternalProject)
 
-  set(OPENSSL_CONFIG_OPTIONS no-unit-test no-shared no-asm no-stdio no-idea no-mdc2 no-rc5 --prefix=${CMAKE_BINARY_DIR})
+  set(OPENSSL_CONFIG_OPTIONS no-unit-test no-shared no-stdio no-idea no-mdc2 no-rc5 --prefix=${CMAKE_BINARY_DIR})
+  if(NOT WithOpenSSLASM)
+    set(OPENSSL_CONFIG_OPTIONS no-asm ${OPENSSL_CONFIG_OPTIONS})
+  endif()
 
   if(WIN32)
       if("${CMAKE_GENERATOR}" MATCHES "(Win64|IA64)")


### PR DESCRIPTION
Closes #197 

Note also that [OpenSSL's INSTALL file](https://github.com/openssl/openssl/blob/master/INSTALL#L269-L273) says the following about the no-asm config setting:
```
   no-asm
                   Do not use assembler code. This should be viewed as
                   debugging/trouble-shooting option rather than production.
                   On some platforms a small amount of assembler code may
                   still be used even with this option.
```

Would it make sense to restructure CMakeLists.txt/make.bat/Makefile so that WithOpenSSLASM=ON is more of a default? Right now `no-asm` is the default and you have to do `make regular-asm` to get what OpenSSL recommends.