### PR TITLE
Use appveyor to build/release Windows binaries

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ configuration: Release
 environment:
   matrix:
     - BUILD_TYPE: tiny
+    - BUILD_TYPE: tiny32
     - BUILD_TYPE: regular-asm
     - BUILD_TYPE: regular32-asm
 
@@ -22,10 +23,26 @@ build_script:
 test_script:
  - Make.bat test
 
+after_build:
+ - Make.bat artifacts-%BUILD_TYPE%
+
 artifacts:
- - path: luvi.exe
+ - path: artifacts\*.exe
+ - path: artifacts\*.lib
 
 cache:
   - C:\ProgramData\chocolatey\bin -> appveyor.yml
   - C:\ProgramData\chocolatey\lib -> appveyor.yml
   - C:\Program Files\NASM -> appveyor.yml
+
+deploy:
+  description: '' # appveyor says this is mandatory
+  provider: GitHub
+  auth_token:
+    secure: Z1U2OG/0SsMQWFB4ReA0R/661E/r4PS2IVJ+jXC7UOBdj78TBjdmtJeUIWaCLoLQ
+  artifact: /.*/ # everything
+  draft: false
+  prerelease: false
+  force_update: true
+  on:
+    APPVEYOR_REPO_TAG: true # tags only

--- a/make.bat
+++ b/make.bat
@@ -81,6 +81,36 @@ git clean -f -d
 git checkout .
 GOTO :end
 
+:artifacts-tiny
+IF NOT EXIST artifacts MKDIR artifacts
+COPY build\Release\luvi.exe artifacts\luvi-tiny-Windows-amd64.exe
+COPY build\Release\luvi.lib artifacts\luvi-tiny-Windows-amd64.lib
+COPY build\Release\luvi_renamed.lib artifacts\luvi_renamed-tiny-Windows-amd64.lib
+GOTO :end
+
+:artifacts-tiny32
+IF NOT EXIST artifacts MKDIR artifacts
+COPY build\Release\luvi.exe artifacts\luvi-tiny-Windows-ia32.exe
+COPY build\Release\luvi.lib artifacts\luvi-tiny-Windows-ia32.lib
+COPY build\Release\luvi_renamed.lib artifacts\luvi_renamed-tiny-Windows-ia32.lib
+GOTO :end
+
+:artifacts-regular
+:artifacts-regular-asm
+IF NOT EXIST artifacts MKDIR artifacts
+COPY build\Release\luvi.exe artifacts\luvi-regular-Windows-amd64.exe
+COPY build\Release\luvi.lib artifacts\luvi-regular-Windows-amd64.lib
+COPY build\Release\luvi_renamed.lib artifacts\luvi_renamed-regular-Windows-amd64.lib
+GOTO :end
+
+:artifacts-regular32
+:artifacts-regular32-asm
+IF NOT EXIST artifacts MKDIR artifacts
+COPY build\Release\luvi.exe artifacts\luvi-regular-Windows-ia32.exe
+COPY build\Release\luvi.lib artifacts\luvi-regular-Windows-ia32.lib
+COPY build\Release\luvi_renamed.lib artifacts\luvi_renamed-regular-Windows-ia32.lib
+GOTO :end
+
 :publish-tiny
 CALL make.bat reset
 CALL make.bat tiny


### PR DESCRIPTION
Only does the deploy phase for tagged commits

Contributes towards #200

---

Tested and confirmed to work. Example:
 - Release: https://github.com/squeek502/luvi/releases/tag/v2.9.2-test2
(the bug that caused regular32 not to get included in the release is fixed in this PR)
 - Job: https://ci.appveyor.com/project/squeek502/luvi/builds/23387487
 - Version Output: `luvi.exe v2.9.2-test2` (i.e. it uses the tag for the version properly)

Note that the `auth_token` used in this PR is one I generated, and I think it'll work for the `luvit/luvi` repo, but maybe it makes more sense for someone else to generate it? See https://www.appveyor.com/docs/deployment/github/#provider-settings for more info about `auth_token`