### PR TITLE
Use travis to build/release Linux binaries 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,28 @@ notifications:
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: false     # default: false
+
+jobs:
+  include:
+    - stage: deploy
+      if: tag IS present
+      os: linux
+      env: []
+      script:
+        # fetch tags so that git describe works
+        - git fetch --unshallow
+        - make linux-build
+      services:
+        - docker
+      deploy:
+        provider: releases
+        api_key: $GITHUB_OAUTH_TOKEN
+        file:
+          - "luvi-regular-Linux_x86_64"
+          - "luvi-tiny-Linux_x86_64"
+          - "luvi-regular-Linux_i686"
+          - "luvi-tiny-Linux_i686"
+        overwrite: true
+        skip_cleanup: true
+        on:
+          tags: true

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ linux-build-box32-regular: luvi-src.tar.gz
 	rm -rf build && mkdir -p build
 	cp packaging/holy-build.sh luvi-src.tar.gz build
 	docker run -t -i --rm \
-		  -v `pwd`/build:/io phusion/holy-build-box-32:latest bash /io/holy-build.sh regular-asm
+		  -v `pwd`/build:/io phusion/holy-build-box-32:latest linux32 bash /io/holy-build.sh regular-asm
 	mv build/luvi luvi-regular-Linux_i686
 
 linux-build-box-tiny: luvi-src.tar.gz
@@ -133,7 +133,7 @@ linux-build-box32-tiny: luvi-src.tar.gz
 	rm -rf build && mkdir -p build
 	cp packaging/holy-build.sh luvi-src.tar.gz build
 	docker run -t -i --rm \
-		  -v `pwd`/build:/io phusion/holy-build-box-32:latest bash /io/holy-build.sh tiny
+		  -v `pwd`/build:/io phusion/holy-build-box-32:latest linux32 bash /io/holy-build.sh tiny
 	mv build/luvi luvi-tiny-Linux_i686
 
 publish-src: reset luvi-src.tar.gz

--- a/packaging/holy-build.sh
+++ b/packaging/holy-build.sh
@@ -21,4 +21,6 @@ make ${BUILD_TYPE}
 make -j${NPROCS}
 ldd build/luvi
 libcheck build/luvi
+# holy-build-box adds -g to CFLAGS, so we need to strip
+strip --strip-all build/luvi
 cp build/luvi /io

--- a/packaging/holy-build.sh
+++ b/packaging/holy-build.sh
@@ -13,7 +13,10 @@ source /hbb_exe/activate
 set -x
 
 # Extract and enter source
-tar xzf /io/luvi-src.tar.gz
+# Use /luvi dir to avoid CMake assertion failure in /
+mkdir -p luvi
+tar xzf /io/luvi-src.tar.gz --directory luvi
+cd luvi
 make ${BUILD_TYPE}
 make -j${NPROCS}
 ldd build/luvi


### PR DESCRIPTION
Uses docker & holy-build-box to build x86_64 and i686 binaries for tagged commits.

Contributes towards #200

---

Tested and confirmed to work. Example:
 - Release: https://github.com/squeek502/luvi/releases/tag/v2.9.2-test5
 - Job: https://travis-ci.org/squeek502/luvi/builds/512945133
 - Version Output: `luvi v2.9.2-test5` (i.e. it uses the tag for the version properly)