### PR TITLE
Add regular-shared make target for shared openssl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ ifdef WITHOUT_AMALG
 endif
 
 WITH_SHARED_LIBLUV ?= OFF
-SHAREDSSL ?= OFF
 
 CMAKE_FLAGS += \
 	-DWithSharedLibluv=$(WITH_SHARED_LIBLUV)
@@ -65,10 +64,14 @@ tiny: deps/luv/CMakeLists.txt
 
 # Configure the build with openssl statically included
 regular: deps/luv/CMakeLists.txt
-	cmake $(CMAKE_FLAGS) $(CPACK_FLAGS) -DWithOpenSSL=ON -DWithSharedOpenSSL=$(SHAREDSSL) -DWithPCRE=ON -DWithLPEG=ON -DWithSharedPCRE=OFF
+	cmake $(CMAKE_FLAGS) $(CPACK_FLAGS) -DWithOpenSSL=ON -DWithSharedOpenSSL=OFF -DWithPCRE=ON -DWithLPEG=ON -DWithSharedPCRE=OFF
 
 regular-asm: deps/luv/CMakeLists.txt
-	cmake $(CMAKE_FLAGS) $(CPACK_FLAGS) -DWithOpenSSL=ON -DWithSharedOpenSSL=$(SHAREDSSL) -DWithOpenSSLASM=ON -DWithPCRE=ON -DWithLPEG=ON -DWithSharedPCRE=OFF
+	cmake $(CMAKE_FLAGS) $(CPACK_FLAGS) -DWithOpenSSL=ON -DWithSharedOpenSSL=OFF -DWithOpenSSLASM=ON -DWithPCRE=ON -DWithLPEG=ON -DWithSharedPCRE=OFF
+
+# Configure the build with shared openssl
+regular-shared:
+	cmake $(CMAKE_FLAGS) $(CPACK_FLAGS) -DWithOpenSSL=ON -DWithSharedOpenSSL=ON -DWithPCRE=ON -DWithLPEG=ON -DWithSharedPCRE=OFF
 
 package: deps/luv/CMakeLists.txt
 	cmake --build build -- package


### PR DESCRIPTION
Makes it a bit more convenient to build with shared openssl, but keeps static openssl as the default

Closes #178