### PR TITLE
Fix 'openssl-skip-update' make target not found with older CMake versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,5 @@
 language: c
 
-addons:
-  apt:
-    sources:
-    - kalakris-cmake
-    packages:
-    - cmake
-
 sudo: false
 
 env:

--- a/deps/openssl.cmake
+++ b/deps/openssl.cmake
@@ -38,8 +38,6 @@ else (WithSharedOpenSSL)
       CONFIGURE_COMMAND ${OPENSSL_CONFIGURE_COMMAND}
       INSTALL_COMMAND   ""
       TEST_COMMAND      ""
-      UPDATE_COMMAND    ""
-      UPDATE_DISCONNECTED YES
   )
   
   set(OPENSSL_DIR ${CMAKE_BINARY_DIR}/openssl/src/openssl)


### PR DESCRIPTION
There's no real need to specify UPDATE_COMMAND or UPDATE_DISCONNECTED since as far as I can tell there is no default update step for URL sources, so there's no update that we need to skip.

In older CMake versions, specifying a custom update step with/without UPDATE_DISCONNECTED could cause this error.

CMake bug: https://cmake.org/Bug/view.php?id=15904
CMake docs: https://cmake.org/cmake/help/v3.11/module/ExternalProject.html

Closes #208