### PR TITLE
fix the VERSION file detection in the build script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,8 @@ if(CMAKE_COMPILER_IS_GNUCC)
   add_definitions( -Wno-unused-function)
 endif()
 
-if (EXISTS "VERSION")
-  file (STRINGS "VERSION" LUVI_VERSION)
+if (EXISTS "${CMAKE_SOURCE_DIR}/VERSION")
+  file (STRINGS "${CMAKE_SOURCE_DIR}/VERSION" LUVI_VERSION)
   message("-- Found luvi version: ${LUVI_VERSION}")
 else()
   exec_program(


### PR DESCRIPTION
When performing a build of luvi outside of the source repository or without git, it relies on the presence of a VERSION file. However, it doesn't actually check in the source directory for the VERSION file, meaning it can't find the file, and breaks, putting a git error message in the version number.

This change makes it actually check in the source directory for the VERSION file so it can reliably find it wherever it gets run.