### PR TITLE
Fixes utf8.charpattern in Lua 5.1

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1,0 +1,5 @@
+local emoji = "🎃"
+assert(utf8.len(emoji) == 1)
+assert(utf8.char(0x1F383) == emoji)
+assert(emoji:match(utf8.charpattern) == emoji)
+print(utf8.offset(emoji, 1) == 1)

--- a/main.lua
+++ b/main.lua
@@ -1,5 +1,0 @@
-local emoji = "🎃"
-assert(utf8.len(emoji) == 1)
-assert(utf8.char(0x1F383) == emoji)
-assert(emoji:match(utf8.charpattern) == emoji)
-print(utf8.offset(emoji, 1) == 1)

--- a/samples/test.app/main.lua
+++ b/samples/test.app/main.lua
@@ -248,6 +248,14 @@ if options.rex then
   assert(#colors == 3)
 end
 
+print("Testing utf8")
+
+local emoji = "🎃"
+assert(utf8.len(emoji) == 1)
+assert(utf8.char(0x1F383) == emoji)
+assert(emoji:match(utf8.charpattern) == emoji)
+assert(utf8.offset(emoji, 1) == 1)
+
 print("All tests pass!\n")
 
 require('uv').run()

--- a/src/luvi_compat.c
+++ b/src/luvi_compat.c
@@ -14,6 +14,13 @@
 #ifndef LUA_UTF8LIBNAME
 #define LUA_UTF8LIBNAME	"utf8"
 #endif
+
+#if (LUA_VERSION_NUM == 501)
+#ifndef UTF8PATT_501
+#define UTF8PATT_501 "[%z\x01-\x7F\xC2-\xF4][\x80-\xBF]*"
+#endif
+#endif
+
 void luvi_openlibs(lua_State *L) {
   luaL_openlibs(L);
 #if (LUA_VERSION_NUM!=503)
@@ -27,8 +34,16 @@ void luvi_openlibs(lua_State *L) {
 
     luaL_register(L, LUA_STRLIBNAME, funcs);
   }
+  lua_pop(L, 1);
 
   luaL_requiref(L, LUA_UTF8LIBNAME, luaopen_utf8, 1);
+
+#if (LUA_VERSION_NUM == 501)
+
+  lua_pushlstring(L, UTF8PATT_501, sizeof(UTF8PATT_501)/sizeof(char) - 1);
+  lua_setfield(L, -2, "charpattern");
   lua_pop(L, 1);
+
+#endif
 #endif
 }

--- a/src/luvi_compat.c
+++ b/src/luvi_compat.c
@@ -39,11 +39,10 @@ void luvi_openlibs(lua_State *L) {
   luaL_requiref(L, LUA_UTF8LIBNAME, luaopen_utf8, 1);
 
 #if (LUA_VERSION_NUM == 501)
-
   lua_pushlstring(L, UTF8PATT_501, sizeof(UTF8PATT_501)/sizeof(char) - 1);
   lua_setfield(L, -2, "charpattern");
+#endif
   lua_pop(L, 1);
 
-#endif
 #endif
 }


### PR DESCRIPTION
Closes #218 

I decided to fix this directly in the C file. Note that `lua_pop` was only called once after requiring the utf8 module. I don't know if this does anything practical, but if it's necessary, I also added a pop for the string module.

Also note that this file seems to mix functions from different Lua versions:

- `luaL_register` is unique to 5.1. It was deprecated in 5.2 in favor of `luaL_setfuncs`.
- `luaL_requiref` was added in 5.2. I guess this is made possible by the presence of the 5.3-compat library.

