### PR TITLE
make.bat: use cmake -A to specify architecture 

### DIFF
--- a/deps/openssl.cmake
+++ b/deps/openssl.cmake
@@ -17,7 +17,7 @@ else (WithSharedOpenSSL)
   endif()
 
   if(WIN32)
-      if("${CMAKE_GENERATOR}" MATCHES "(Win64|IA64)")
+      if("${CMAKE_GENERATOR_PLATFORM}" MATCHES "x64")
         set(OPENSSL_CONFIGURE_COMMAND perl ./Configure VC-WIN64A ${OPENSSL_CONFIG_OPTIONS})
       else()
         set(OPENSSL_CONFIGURE_COMMAND perl ./Configure VC-WIN32 ${OPENSSL_CONFIG_OPTIONS})

--- a/make.bat
+++ b/make.bat
@@ -10,7 +10,6 @@ reg query HKEY_CLASSES_ROOT\VisualStudio.DTE.15.0 >nul 2>nul
 IF %errorlevel%==0 set GENERATOR=Visual Studio 15
 reg query HKEY_CLASSES_ROOT\VisualStudio.DTE.16.0 >nul 2>nul
 IF %errorlevel%==0 set GENERATOR=Visual Studio 16
-set GENERATOR64=%GENERATOR% Win64
 
 for /f %%i in ('git describe') do set LUVI_TAG=%%i
 IF NOT "x%1" == "x" GOTO :%1
@@ -19,32 +18,32 @@ GOTO :build
 
 :regular
 ECHO "Building regular64"
-cmake -DWithOpenSSL=ON -DWithSharedOpenSSL=OFF -DWithPCRE=ON -DWithLPEG=ON -DWithSharedPCRE=OFF -H. -Bbuild  -G"%GENERATOR64%"
+cmake -DWithOpenSSL=ON -DWithSharedOpenSSL=OFF -DWithPCRE=ON -DWithLPEG=ON -DWithSharedPCRE=OFF -H. -Bbuild -G"%GENERATOR%" -Ax64
 GOTO :end
 
 :regular-asm
 ECHO "Building regular64 asm"
-cmake -DWithOpenSSLASM=ON -DWithOpenSSL=ON -DWithSharedOpenSSL=OFF -DWithPCRE=ON -DWithLPEG=ON -DWithSharedPCRE=OFF -H. -Bbuild  -G"%GENERATOR64%"
+cmake -DWithOpenSSLASM=ON -DWithOpenSSL=ON -DWithSharedOpenSSL=OFF -DWithPCRE=ON -DWithLPEG=ON -DWithSharedPCRE=OFF -H. -Bbuild -G"%GENERATOR%" -Ax64
 GOTO :end
 
 :regular32
 ECHO "Building regular32"
-cmake -DWithOpenSSL=ON -DWithSharedOpenSSL=OFF -DWithPCRE=ON -DWithLPEG=ON -DWithSharedPCRE=OFF -H. -Bbuild  -G"%GENERATOR%"
+cmake -DWithOpenSSL=ON -DWithSharedOpenSSL=OFF -DWithPCRE=ON -DWithLPEG=ON -DWithSharedPCRE=OFF -H. -Bbuild -G"%GENERATOR%" -AWin32
 GOTO :end
 
 :regular32-asm
 ECHO "Building regular32 asm"
-cmake -DWithOpenSSLASM=ON -DWithOpenSSL=ON -DWithSharedOpenSSL=OFF -DWithPCRE=ON -DWithLPEG=ON -DWithSharedPCRE=OFF -H. -Bbuild  -G"%GENERATOR%"
+cmake -DWithOpenSSLASM=ON -DWithOpenSSL=ON -DWithSharedOpenSSL=OFF -DWithPCRE=ON -DWithLPEG=ON -DWithSharedPCRE=OFF -H. -Bbuild -G"%GENERATOR%" -AWin32
 GOTO :end
 
 :tiny
 ECHO "Building tiny64"
-cmake -H. -Bbuild -G"%GENERATOR64%"
+cmake -H. -Bbuild -G"%GENERATOR%" -Ax64
 GOTO :end
 
 :tiny32
 ECHO "Building tiny32"
-cmake -H. -Bbuild -G"%GENERATOR%"
+cmake -H. -Bbuild -G"%GENERATOR%" -AWin32
 GOTO :end
 
 :build


### PR DESCRIPTION
`cmake -A` is available since cmake 3.1 (2014).

VS2019 does not allow you to provide the architecture as part of the generator. It must be supplied in the -A switch.

Fixes regression in #239.

*This slipped by the CI because the AppVeyor is still using VS2017.*