### PR TITLE
Update Github oauth token used for releases

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ deploy:
   description: '' # appveyor says this is mandatory
   provider: GitHub
   auth_token:
-    secure: bTslNShNLTsJrZ1cOoWU6gzI4boK7gveIkOzqn7SMwAyHOpb1HkemYgTvfZK2VRI
+    secure: ZQtPAVaybUWlOtbbHkn1HkoE6zrEUE7wjEXUqCA1vdVRqZYHZUvmVowHxzMtQpLC
   artifact: /.*/ # everything
   draft: false
   prerelease: false


### PR DESCRIPTION
See #247

Also updated the Travis token, but that's done through environment variable settings so there's no commit necessary there. Hasn't been tested, but hopefully this fixes it.