### PR TITLE
make: Support lightweight tags when getting luvi version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-LUVI_TAG=$(shell git describe)
+LUVI_TAG=$(shell git describe --tags)
 LUVI_ARCH=$(shell uname -s)_$(shell uname -m)
 LUVI_PUBLISH_USER?=luvit
 LUVI_PUBLISH_REPO?=luvi

--- a/make.bat
+++ b/make.bat
@@ -11,7 +11,7 @@ IF %errorlevel%==0 set GENERATOR=Visual Studio 15
 reg query HKEY_CLASSES_ROOT\VisualStudio.DTE.16.0 >nul 2>nul
 IF %errorlevel%==0 set GENERATOR=Visual Studio 16
 
-for /f %%i in ('git describe') do set LUVI_TAG=%%i
+for /f %%i in ('git describe --tags') do set LUVI_TAG=%%i
 IF NOT "x%1" == "x" GOTO :%1
 
 GOTO :build


### PR DESCRIPTION
The `--version` of the 2.12.0 release is wrong because of this.