### PR TITLE
Ensure that using the -v or -h flags always returns with EXIT_SUCCESS

### DIFF
--- a/src/lua/init.lua
+++ b/src/lua/init.lua
@@ -88,6 +88,8 @@ Examples:
   print((string.gsub(usage, "%$%(LUVI%)", args[0])))
 end
 
+local EXIT_SUCCESS = 0
+
 return function(args)
 
   -- First check for a bundled zip file appended to the executable
@@ -153,7 +155,7 @@ return function(args)
   end
 
   -- Don't run app when printing version or help
-  if options.version or options.help then return -1 end
+  if options.version or options.help then return EXIT_SUCCESS end
 
   -- Build the app if output is given
   if options.output then


### PR DESCRIPTION
Returning ``-1`` indicates an error, assuming the usual convention for exit codes is followed. Seeing how ``main.c`` returns ``-1`` in case of errors, this appears to be the case. Edit: It seems to turn into ``255`` on my Ubuntu system, but that's still interpreted as an error.

Specifically, using either of the two flags in a script or CI workflow will cause it to mistakenly assume an error has occured and fail as a result. I've found this out when I was using ``-v`` in a workflow (for debugging purposes) and it failed the entire run.