### PR TITLE
pass MAKEFLAGS to openssl build

### DIFF
--- a/deps/openssl.cmake
+++ b/deps/openssl.cmake
@@ -25,7 +25,12 @@ else (WithSharedOpenSSL)
       set(OPENSSL_BUILD_COMMAND nmake)
   else()
       set(OPENSSL_CONFIGURE_COMMAND ./config ${OPENSSL_CONFIG_OPTIONS})
-      set(OPENSSL_BUILD_COMMAND make)
+
+      if(DEFINED $ENV{MAKEFLAGS})
+        set(OPENSSL_BUILD_COMMAND make $ENV{MAKEFLAGS})
+      else()
+        set(OPENSSL_BUILD_COMMAND make)
+      endif()
   endif()
 
   ExternalProject_Add(openssl


### PR DESCRIPTION
While poking around with the aarch64 luvi builds I noticed that even though the Makefile passes `-jN` to the initial cmake build, the openssl build does not. This most likely is because ExternalProject doesn't preserve the environment (and therefore the MAKEFLAGS var doesn't exist inside).

This should speed up the luvi regular and regular-asm build for any linux or darwin machine that has more than one core.