### PR TITLE
Fix CMake builds using Visual Studio 2022

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -10,6 +10,8 @@ reg query HKEY_CLASSES_ROOT\VisualStudio.DTE.15.0 >nul 2>nul
 IF %errorlevel%==0 set GENERATOR=Visual Studio 15
 reg query HKEY_CLASSES_ROOT\VisualStudio.DTE.16.0 >nul 2>nul
 IF %errorlevel%==0 set GENERATOR=Visual Studio 16
+reg query HKEY_CLASSES_ROOT\VisualStudio.DTE.17.0 >nul 2>nul
+IF %errorlevel%==0 set GENERATOR=Visual Studio 17
 
 for /f %%i in ('git describe --tags') do set LUVI_TAG=%%i
 IF NOT "x%1" == "x" GOTO :%1


### PR DESCRIPTION
It tried to use 2019 by default, and that'll fail if only 2022 is installed. This minor change should have no side effects in other scenarios.

Before:

![image](https://user-images.githubusercontent.com/16489133/170718809-de9f9792-e49f-4824-815a-82600dcac71f.png)

After:

![image](https://user-images.githubusercontent.com/16489133/170718866-43310f15-3144-44a2-af78-b238ef80bbc1.png)
