### PR TITLE
Fixes build forcing during Lua load error

### DIFF
--- a/src/lua/luvibundle.lua
+++ b/src/lua/luvibundle.lua
@@ -195,10 +195,10 @@ local function buildBundle(options, bundle)
 
           if compile and isLua and name:lower() ~= 'package.lua' then
             local fn, err = load(ctx, child)
-            if not fn and not options.force then
-              error(err)
-            else
+            if fn then
               ctx = string.dump(fn, options.strip)
+            elseif not options.force then
+              error(err)
             end
           end
 


### PR DESCRIPTION
Bug introduced in #276:

```lua
if compile and isLua and name:lower() ~= 'package.lua' then
  local fn, err = load(ctx, child)
  if not fn and not options.force then
    error(err)
  else
    ctx = string.dump(fn, options.strip)
  end
end
```

When `load` fails, `fn` is `nil`. If `options.force` is `true`, `string.dump` is called with `nil` and also fails.

This change removes the attempt to call `string.dump` with `nil`. Obviously, the resulting code will not be compiled or stripped in the bundle.