### PR TITLE
various fixes for building with shared libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,27 @@ name: CI
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
+  check-shared:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        submodules: recursive
+
+    - name: Ensure dependencies are installed
+      run: |
+        sudo apt-get install -y libssl-dev libpcre2-dev zlib1g-dev lua-luv-dev libluajit-5.1-dev luajit
+
+    - name: Configure
+      run: make regular WITH_SHARED_LIBLUV=ON WITH_SHARED_OPENSSL=ON WITH_SHARED_PCRE2=ON WITH_SHARED_ZLIB=ON
+
+    - name: Build
+      run: make
+
+    - name: Test
+      run: make test
+
   build-posix:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -245,7 +266,7 @@ jobs:
         path: /tmp/luvi-source.tar.gz
 
   publish:
-    needs: [build-posix, build-linux, build-mingw, build-msvc, package-source]
+    needs: [build-posix, build-linux, build-mingw, build-msvc, package-source, check-shared]
     runs-on: ubuntu-latest
     steps:
     - name: Download Artifacts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,16 +62,16 @@ set (LUVI_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
 # When linking against a shared libluv, we assume that luajit and libuv are also shared
 # Luvi does not support linking a static libluv *and* a static lua/luajit or libuv
 if (WithSharedLibluv)
-  find_package(Libluv REQUIRED)
-  include_directories(${LIBLUV_INCLUDE_DIR})
+  find_package(Luv REQUIRED)
+  include_directories(${LUV_INCLUDE_DIRS})
 
   find_package(LuaJIT  REQUIRED)
-  include_directories(${LUAJIT_INCLUDE_DIR})
+  include_directories(${LUAJIT_INCLUDE_DIRS})
 
   find_package(Libuv  REQUIRED)
-  include_directories(${LIBUV_INCLUDE_DIR})
+  include_directories(${LIBUV_INCLUDE_DIRS})
 
-  list(APPEND LUVI_LIBRARIES ${LIBLUV_LIBRARIES} ${LUAJIT_LIBRARIES} ${LIBUV_LIBRARIES})
+  list(APPEND LUVI_LIBRARIES ${LUV_LIBRARIES} ${LUAJIT_LIBRARIES} ${LIBUV_LIBRARIES})
 else (WithSharedLibluv)
   # Build luv as static library instead of as module
   set(BUILD_MODULE OFF CACHE BOOL "Turn off building luv as module")

--- a/cmake/Modules/FindLibuv.cmake
+++ b/cmake/Modules/FindLibuv.cmake
@@ -9,13 +9,13 @@ Result Variables
 
 This module defines the following variables:
 
-``UV_FOUND``
+``LIBUV_FOUND``
   "True" if ``libuv`` found.
 
-``UV_INCLUDE_DIRS``
+``LIBUV_INCLUDE_DIRS``
   where to find ``uv.h``, etc.
 
-``UV_LIBRARIES``
+``LIBUV_LIBRARIES``
   List of libraries when using ``uv``.
 
 #]=======================================================================]
@@ -37,10 +37,10 @@ find_library(UV_LIBRARY
   HINTS ${PC_UV_LIBRARY_DIRS})
 mark_as_advanced(UV_LIBRARY)
 
-find_package_handle_standard_args(uv
+find_package_handle_standard_args(Libuv
   REQUIRED_VARS UV_INCLUDE_DIR UV_LIBRARY)
 
-if (UV_FOUND) # Set the output variables
-  set(UV_LIBRARIES ${UV_LIBRARY})
-  set(UV_INCLUDE_DIRS ${UV_INCLUDE_DIR})
+if (LIBUV_FOUND) # Set the output variables
+  set(LIBUV_LIBRARIES ${UV_LIBRARY})
+  set(LIBUV_INCLUDE_DIRS ${UV_INCLUDE_DIR})
 endif ()

--- a/cmake/Modules/FindLuaJIT.cmake
+++ b/cmake/Modules/FindLuaJIT.cmake
@@ -39,7 +39,7 @@ find_library(LUAJIT_LIBRARY
   PATH_SUFFIXES luajit-2.0)
 mark_as_advanced(LUAJIT_LIBRARY)
 
-find_package_handle_standard_args(luajit
+find_package_handle_standard_args(LuaJIT
   REQUIRED_VARS LUAJIT_INCLUDE_DIR LUAJIT_LIBRARY)
 
 if (LUAJIT_FOUND) # Set the output variables

--- a/cmake/Modules/FindLuv.cmake
+++ b/cmake/Modules/FindLuv.cmake
@@ -25,20 +25,23 @@ include(FindPackageHandleStandardArgs)
 find_package(PkgConfig QUIET)
 if(PKG_CONFIG_FOUND)
   pkg_check_modules(PC_LUV QUIET libluv)
+  if (NOT PC_LUV_FOUND)
+    pkg_check_modules(PC_LUV QUIET lua5.1-luv)
+  endif ()
 endif()
 
 find_path(LUV_INCLUDE_DIR
   NAMES luv.h
   HINTS ${PC_LUV_INCLUDE_DIRS}
-  PATH_SUFFIXES luv)
+  PATH_SUFFIXES luv lua5.1/luv)
 mark_as_advanced(LUV_INCLUDE_DIR)
 
 find_library(LUV_LIBRARY
-  NAMES luv
+  NAMES luv lua5.1-luv
   HINTS ${PC_LUV_LIBRARY_DIRS})
 mark_as_advanced(LUV_LIBRARY)
 
-find_package_handle_standard_args(luv
+find_package_handle_standard_args(Luv
   REQUIRED_VARS LUV_INCLUDE_DIR LUV_LIBRARY)
 
 if (LUV_FOUND) # Set the output variables

--- a/cmake/Modules/FindPCRE2.cmake
+++ b/cmake/Modules/FindPCRE2.cmake
@@ -1,24 +1,46 @@
+#[=======================================================================[.rst:
+FindPCRE2
+--------
 
-FIND_PATH(PCRE2_INCLUDE_DIR NAMES pcre2.h)
+Find the native pcre2 (specifically the 8-bit version) headers and libraries.
 
-# Look for the library.
-FIND_LIBRARY(PCRE2_LIBRARY NAMES pcre2)
+Result Variables
+^^^^^^^^^^^^^^^^
 
-# Handle the QUIETLY and REQUIRED arguments and set PCRE2_FOUND to TRUE if all listed variables are TRUE.
-INCLUDE(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(PCRE2 DEFAULT_MSG PCRE2_LIBRARY PCRE2_INCLUDE_DIR)
+This module defines the following variables:
 
-# Copy the results to the output variables.
-IF(PCRE2_FOUND)
-  SET(PCRE2_LIBRARIES ${PCRE2_LIBRARY})
-  SET(PCRE2_INCLUDE_DIRS ${PCRE2_INCLUDE_DIR})
-  SET(PCRE2_UNIT_WIDTH ${PCRE2_CODE_UNIT_WIDTH})
-ELSE(PCRE2_FOUND)
-  SET(PCRE2_LIBRARIES)
-  SET(PCRE2_INCLUDE_DIRS)
-  SET(PCRE2_UNIT_WIDTH)
-ENDIF(PCRE2_FOUND)
+``PCRE2_FOUND``
+  "True" if ``pcre2-8`` found.
 
-ADD_DEFINITIONS( -DPCRE2_CODE_UNIT_WIDTH=${PCRE2_UNIT_WIDTH} )
+``PCRE2_INCLUDE_DIRS``
+  where to find ``pcre2.h``, etc.
 
-MARK_AS_ADVANCED(PCRE2_INCLUDE_DIRS PCRE2_LIBRARIES PCRE2_UNIT_WIDTH)
+``PCRE2_LIBRARIES``
+  List of libraries when using ``pcre2-8``.
+
+#]=======================================================================]
+
+include(FindPackageHandleStandardArgs)
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_PCRE2 QUIET libpcre2-8)
+endif()
+
+find_path(PCRE2_INCLUDE_DIR
+  NAMES pcre2.h
+  HINTS ${PC_PCRE2_INCLUDE_DIRS})
+mark_as_advanced(PCRE2_INCLUDE_DIR)
+
+find_library(PCRE2_LIBRARY
+  NAMES pcre2-8
+  HINTS ${PC_PCRE2_LIBRARY_DIRS})
+mark_as_advanced(PCRE2_LIBRARY)
+
+find_package_handle_standard_args(PCRE2
+  REQUIRED_VARS PCRE2_INCLUDE_DIR PCRE2_LIBRARY)
+
+if (PCRE2_FOUND) # Set the output variables
+  set(PCRE2_LIBRARIES ${PCRE2_LIBRARY})
+  set(PCRE2_INCLUDE_DIRS ${PCRE2_INCLUDE_DIR})
+endif ()

--- a/deps/pcre2.cmake
+++ b/deps/pcre2.cmake
@@ -4,6 +4,8 @@ if (WithSharedPCRE2)
   message("Enabling Shared PCRE2")
   message("PCRE2_INCLUDE_DIR: ${PCRE2_INCLUDE_DIR}")
   message("PCRE2_LIBRARIES:   ${PCRE2_LIBRARIES}")
+
+  add_compile_definitions(PCRE2_CODE_UNIT_WIDTH=8)
 else (WithSharedPCRE2)
   message("Enabling Static PCRE2")
 


### PR DESCRIPTION
also adds a CI check for building with all shared libraries to ensure they don't regress

Most of these regressions were introduced in #285 as a result of not being covered by CI

Primarily focused on fixing #280