### PR TITLE
fix: adler32's first 16-bit should default to 1 not 0

### DIFF
--- a/src/lminiz.c
+++ b/src/lminiz.c
@@ -356,7 +356,7 @@ static int ltdefl(lua_State* L) {
 }
 
 static int lmz_adler32(lua_State* L) {
-  mz_ulong adler = luaL_optinteger(L, 1, 0);
+  mz_ulong adler = luaL_optinteger(L, 1, 1);
   size_t buf_len = 0;
   const unsigned char* ptr = (const unsigned char*)luaL_optlstring(L, 2, NULL, &buf_len);
   adler = mz_adler32(adler, ptr, buf_len);


### PR DESCRIPTION
Using the default value for the first parameter of `lminiz.adler32` will output invalid checksum due to improper defaults.

For example:
```lua
local miniz = requrie("miniz")
miniz.adler32(nil, "luvit") --> 110625332
```
Which is wrong, it should instead be `110953013` (`0x069D0235`).
For reference take the output of an online calculatore like [this one](https://miniwebtool.com/adler32-checksum-calculator/) or even the [Wikipedia example](https://en.wikipedia.org/wiki/Adler-32#Example).


An Adler32 checksum is 32-bit number made of two 16-bit groups A and B, group A should initiate with `1` and group B should initiate with `0`. Currently by default group A will default to `0` instead of `1`.

@zhaozg Is this right?
