### PR TITLE
lminiz: return nil on inflate/deflate failure

### DIFF
--- a/src/lminiz.c
+++ b/src/lminiz.c
@@ -17,7 +17,7 @@
 
 #include "./luvi.h"
 #define MINIZ_NO_ZLIB_COMPATIBLE_NAMES
-#include "../deps/miniz.c"
+#include "../deps/miniz/miniz.h"
 
 typedef struct {
   mz_zip_archive archive;


### PR DESCRIPTION
When miniz returns `null` on `tdefl_compress_mem_to_heap` and `tinfl_decompress_mem_to_heap` singling an error, lminiz will still return a string to the end user, an empty string in this case.  This pull changes this behavior to return back a `nil` value plus an error message to be consistent with the rest of the API.

This change may not be necessarily wanted, as an empty string should still be valid for an error indication, as it seems miniz refuse to inflate a ZLib-ed empty string (i.e. an empty string with zlib header only, e.g. `miniz.deflate("")`).   
