### PR TITLE
lminiz: return nil on deflate/inflate failure

### DIFF
--- a/src/lminiz.c
+++ b/src/lminiz.c
@@ -340,6 +340,11 @@ static int ltinfl(lua_State* L) {
   size_t out_len;
   int flags = luaL_optinteger(L, 2, 0);
   char* out_buf = tinfl_decompress_mem_to_heap(in_buf, in_len, &out_len, flags);
+  if (!out_buf) {
+    lua_pushnil(L);
+    lua_pushstring(L, "Problem inflating data into memory");
+    return 2;
+  }
   lua_pushlstring(L, out_buf, out_len);
   free(out_buf);
   return 1;
@@ -351,6 +356,11 @@ static int ltdefl(lua_State* L) {
   size_t out_len;
   int flags = luaL_optinteger(L, 2, 0);
   char* out_buf = tdefl_compress_mem_to_heap(in_buf, in_len, &out_len, flags);
+  if (!out_buf) {
+    lua_pushnil(L);
+    lua_pushstring(L, "Problem deflating data into memory");
+    return 2;
+  }
   lua_pushlstring(L, out_buf, out_len);
   free(out_buf);
   return 1;


### PR DESCRIPTION
When miniz returns `NULL` on `tdefl_compress_mem_to_heap` and `tinfl_decompress_mem_to_heap` signaling an error, lminiz will still return a string to the end user, an empty string in this case.  This pull changes this behavior to return back a `nil` value plus an error message to be consistent with the rest of the API.

This change may not be necessarily wanted, as an empty string should still be valid for an error indication, as it seems miniz refuse to inflate a ZLib-ed empty string (i.e. an empty string with zlib header only, e.g. `miniz.deflate("")`).   
