### PR TITLE
enforce lua version compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,20 @@ if (WithSharedLibluv)
   find_package(Libuv  REQUIRED)
   include_directories(${LIBUV_INCLUDE_DIRS})
 
+  include(CheckCSourceCompiles)
+  
+  set(CMAKE_REQUIRED_INCLUDES ${LUAJIT_INCLUDE_DIRS})
+  set(CMAKE_REQUIRED_LIBRARIES ${LUAJIT_LIBRARIES})
+  check_c_source_compiles("
+  #include <luajit.h>
+  int main() {
+    LUAJIT_VERSION_SYM();
+    return 0;
+  }" LUAJIT_HAS_VERSION_SYM)
+  if (NOT LUAJIT_HAS_VERSION_SYM)
+    add_compile_definitions(LUAJIT_MISSING_VERSION_SYM)
+  endif ()
+
   list(APPEND LUVI_LIBRARIES ${LUV_LIBRARIES} ${LUAJIT_LIBRARIES} ${LIBUV_LIBRARIES})
 else (WithSharedLibluv)
   # Build luv as static library instead of as module

--- a/src/luvi.h
+++ b/src/luvi.h
@@ -22,6 +22,9 @@
 #include "lauxlib.h"
 #include "uv.h"
 #include "luv.h"
+#ifndef WITH_PLAIN_LUA
+#include "luajit.h"
+#endif
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/main.c
+++ b/src/main.c
@@ -55,6 +55,17 @@ static lua_State* vm_acquire(){
   if (L == NULL)
     return L;
 
+  // Ensure that the version of lua interpreter is compatible with the version luvi was compiled with.
+#ifdef WITH_PLAIN_LUA
+#if (LUA_VERSION_NUM >= 502)
+  luaL_checkversion(L);
+#endif
+#else
+#ifndef LUAJIT_MISSING_VERSION_SYM // debian patches luajit to remove this symbol, so we can't check it.
+  LUAJIT_VERSION_SYM();
+#endif
+#endif
+
   // Add in the lua standard and compat libraries
   luvi_openlibs(L);
 


### PR DESCRIPTION
A portion of Luvi code is embedded into the binary as bytecode. This poses an issue in builds with shared libluv (and therefore shared luajit) where the version of Lua(JIT) used to compile Luvi may be different from the version present on the target machine.

Both LuaJIT and PUC Lua 5.2+ provide mechanisms to emit an error when this occurs. In PUC Lua this is done via `luaL_checkversion(L)` which throws a Lua error when it fails. We call this as soon as we create a new state to ensure that the error is fatal.

In LuaJIT this is done via an exported symbol `LUAJIT_VERSION_SYM` that matches the version of LuaJIT during compilation. The dynamic loader will fail if this symbol cannot be found in the LuaJIT dynamic library.

These checks happen on a best effort basis: some distributions (like Ubuntu) use patched versions of LuaJIT that is missing `LUAJIT_VERSION_SYM`, and `luaL_checkversion(L)` was implemented in 5.2, and as such is missing in 5.1.