### PR TITLE
fix: add `no-module` to openssl static build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
 
     - name: Ensure dependencies are installed
       run: |
+        sudo apt-get update
         sudo apt-get install -y libssl-dev libpcre2-dev zlib1g-dev lua-luv-dev libluajit-5.1-dev luajit
 
     - name: Configure
@@ -95,6 +96,7 @@ jobs:
     - name: Setup QEMU
       if: matrix.arch == 'aarch64'
       run: |
+        sudo apt-get update
         sudo apt-get install -y qemu-user-static
 
     - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@ if (MINGW)
   add_compile_options(-Wno-error=incompatible-pointer-types)
 endif ()
 
+if (CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
+  add_compile_options(-Wno-incompatible-pointer-types)
+endif()
+
 if (UNIX)
   add_compile_options(-Wall)
 endif ()

--- a/deps/openssl.cmake
+++ b/deps/openssl.cmake
@@ -13,7 +13,7 @@ else (WithSharedOpenSSL)
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 
-  set(OPENSSL_CONFIG_OPTIONS no-tests no-shared no-pinshared no-makedepend --prefix=${CMAKE_BINARY_DIR})
+  set(OPENSSL_CONFIG_OPTIONS no-tests no-module no-shared no-pinshared no-makedepend --prefix=${CMAKE_BINARY_DIR})
   if (OPENSSL_CONFIG_DIR)
     message("Using existing OpenSSL configuration directory: ${OPENSSL_CONFIG_DIR}")
     set(OPENSSL_CONFIG_OPTIONS ${OPENSSL_CONFIG_OPTIONS} --openssldir=${OPENSSL_CONFIG_DIR})


### PR DESCRIPTION
Ever since the update to openssl 3.x we have been building static openssl ever so slightly incorrect. Without the `no-module` configuration option openssl still tries to provide some non-core modules (like the legacy provider) as a shared library. However luvi has no way to bundle this, and so ever since the update to openssl 3.x we have been unable to use any of the legacy ciphers in luvi.

This was only observable by checking the list of openssl errors, because lua-openssl attempts to load both the default and legacy providers without handling any errors.

I used the following script to ensure the provided fix actually works for the legacy provider:

```lua
local openssl = require 'openssl'

print(openssl.errors())

local ctx = openssl.cipher.get('blowfish') -- any cipher provided by legacy works here
print(ctx)

print(ctx:cipher('123', '456', '789'))
```

Before this fix:

```
C06BE223E67B0000:error:12800067:DSO support routines:dlfcn_load:could not load the shared library:crypto/dso/dso_dlfcn.c:118:filename(.../lib64/ossl-modules/legacy.so): .../lib64/ossl-modules/legacy.so: cannot open shared object file: No such file or directory
C06BE223E67B0000:error:12800067:DSO support routines:DSO_load:could not load the shared library:crypto/dso/dso_lib.c:147:
C06BE223E67B0000:error:07880025:common libcrypto routines:provider_init:reason(37):crypto/provider_core.c:950:name=legacy

openssl.evp_cipher: 0x7be623dd52d8
nil     unsupported     50856204
```

After this fix:

```

openssl.evp_cipher: 0x7fca1a4d8a98
�r���H�
```

Alongside fixing the static build of openssl, this also fixes the intermittent issue with lua-openssl triggering the incompatible pointer types error by silencing the warning for lua-openssl, which it does internally but only for clang.