### PR TITLE
mark bundle files as "files", use luaL_traceback

### DIFF
--- a/src/lua/luvibundle.lua
+++ b/src/lua/luvibundle.lua
@@ -194,7 +194,7 @@ local function buildBundle(options, bundle)
           local compile = options.strip or options.compile
 
           if compile and isLua and name:lower() ~= 'package.lua' then
-            local fn, err = load(ctx, child)
+            local fn, err = load(ctx, '@' .. child)
             if fn then
               ctx = string.dump(fn, options.strip)
             elseif not options.force then
@@ -333,7 +333,7 @@ local function commonBundle(bundlePaths, mainPath, args)
     if not path then path = name + ".lua" end
     package.preload[name] = function (...)
       local lua = assert(bundle.readfile(path))
-      return assert(loadstring(lua, "bundle:" .. path))(...)
+      return assert(loadstring(lua, "@bundle:" .. path))(...)
     end
   end
 
@@ -360,7 +360,7 @@ local function commonBundle(bundlePaths, mainPath, args)
   else
     local main = bundle.readfile(mainPath)
     if not main then error("Missing " .. mainPath .. " in " .. bundle.base) end
-    local fn = assert(loadstring(main, "bundle:" .. mainPath))
+    local fn = assert(loadstring(main, "@bundle:" .. mainPath))
     return fn(unpack(args))
   end
 end

--- a/src/luvi.h
+++ b/src/luvi.h
@@ -38,6 +38,9 @@
 
 #if (LUA_VERSION_NUM < 503)
 #include "compat-5.3.h"
+#ifndef WITH_PLAIN_LUA
+#undef luaL_traceback /* luajit has its own version */
+#endif
 #endif
 
 #ifdef WITH_OPENSSL

--- a/src/main.c
+++ b/src/main.c
@@ -32,21 +32,7 @@ int luvi_custom(lua_State* L);
 static int luvi_traceback(lua_State *L) {
   if (!lua_isstring(L, 1))  /* 'message' not a string? */
     return 1;  /* keep it intact */
-  lua_pushglobaltable(L);
-  lua_getfield(L, -1, "debug");
-  lua_remove(L, -2);
-  if (!lua_istable(L, -1)) {
-    lua_pop(L, 1);
-    return 1;
-  }
-  lua_getfield(L, -1, "traceback");
-  if (!lua_isfunction(L, -1)) {
-    lua_pop(L, 2);
-    return 1;
-  }
-  lua_pushvalue(L, 1);  /* pass error message */
-  lua_pushinteger(L, 2);  /* skip this function and traceback */
-  lua_call(L, 2, 1);  /* call debug.traceback */
+  luaL_traceback(L, L, lua_tostring(L, -1), 1);
   return 1;
 }
 


### PR DESCRIPTION
Two small changes here:

1. Prepends `@` to the chunk name of bundled files so that the shortsrc name becomes `bundle:file` instead of `[string "bundle:file"]` in error messages. This is mostly just a convenience thing because the `[string ""]` just clutters the output on error.

2. Luvi now uses `luaL_traceback` instead of calling `debug.traceback`. We have lua53-compat which backfills this function for PUC 5.1 and it's available by default from every other Lua we support.