### PR TITLE
fix: improper enviornment check

### DIFF
--- a/cmake/Modules/LuaAddExecutable.cmake
+++ b/cmake/Modules/LuaAddExecutable.cmake
@@ -14,8 +14,8 @@ macro(LUA_ADD_EXECUTABLE target)
     set(LUA_COMMAND lua)
   endif ()
 
-  if ($ENV{LUA_PATH})
-    set(LUA_COMMAND ${CMAKE_COMMAND} -E env LUA_PATH=$ENV{LUA_PATH} -- ${LUA_COMMAND})
+  if (DEFINED ENV{LUA_PATH})
+    set(LUA_COMMAND ${CMAKE_COMMAND} -E env "LUA_PATH=$ENV{LUA_PATH}" -- ${LUA_COMMAND})
   endif ()
 
   set(target_sources)


### PR DESCRIPTION
Causes a CMake error if LUA_PATH is set, due to a bad check.

```sh
$ make tiny
CMake Error at cmake/Modules/LuaAddExecutable.cmake:17 (if):
  if given arguments:

    "/usr/share/lua/5.4/?.lua" "/usr/share/lua/5.4/?/init.lua" "/usr/lib64/lua/5.4/?.lua" "/usr/lib64/lua/5.4/?/init.lua" "./?.lua" "./?/init.lua"

  Unknown arguments specified
Call Stack (most recent call first):
  CMakeLists.txt:160 (lua_add_executable)

```
