### PR TITLE
fix(luvibundle): inconsistent arguments to action callback

### DIFF
--- a/src/lua/luvibundle.lua
+++ b/src/lua/luvibundle.lua
@@ -313,7 +313,7 @@ local function commonBundle(bundlePaths, mainPath, args)
 
   function bundle.action(path, action, ...)
     -- If it's a real path, run it directly.
-    if uv.fs_access(path, "r") then return action(path) end
+    if uv.fs_access(path, "r") then return action(path, ...) end
     -- Otherwise, copy to a temporary folder and run from there
     local data, err = bundle.readfile(path)
     if not data then return nil, err end


### PR DESCRIPTION
I randomly noticed this, I can't think of a reason why would the callback be called with the varargs on the second route but not the first one.